### PR TITLE
Refine personal finance UI workflow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -304,8 +304,30 @@ function App() {
           setSelectedPersonalFinanceCardId(resolvedCardId)
         }
 
-        const snapshots = await Promise.all(
-          cards.map((card) =>
+        const selectedSnapshot = await apiClient.getPersonalFinanceSnapshot(
+          resolvedCardId,
+          selectedPersonalFinanceYear,
+          controller.signal,
+        )
+
+        if (controller.signal.aborted) {
+          return
+        }
+
+        setPersonalFinanceCards(
+          cards.map((card) => ({
+            ...card,
+            currentBalance:
+              card.id === selectedSnapshot.card.id ? selectedSnapshot.settings.currentBalance : null,
+            currency: card.id === selectedSnapshot.card.id ? selectedSnapshot.currency : null,
+          })),
+        )
+        setPersonalFinanceSnapshot(selectedSnapshot)
+        setPersonalFinanceStatus('ready')
+
+        const otherCards = cards.filter((card) => card.id !== resolvedCardId)
+        const otherSnapshotResults = await Promise.allSettled(
+          otherCards.map((card) =>
             apiClient.getPersonalFinanceSnapshot(card.id, selectedPersonalFinanceYear, controller.signal),
           ),
         )
@@ -314,21 +336,44 @@ function App() {
           return
         }
 
-        const cardsWithSummaries: PersonalFinanceCardListItem[] = cards.map((card) => {
-          const cardSnapshot = snapshots.find((snapshot) => snapshot.card.id === card.id)
-
-          return {
-            ...card,
-            currentBalance: cardSnapshot?.settings.currentBalance ?? null,
-            currency: cardSnapshot?.currency ?? null,
+        const summaryByCardId = new Map<
+          string,
+          {
+            currentBalance: string | null
+            currency: string | null
           }
-        })
-        const selectedSnapshot =
-          snapshots.find((snapshot) => snapshot.card.id === resolvedCardId) ?? snapshots[0] ?? null
+        >([
+          [
+            selectedSnapshot.card.id,
+            {
+              currentBalance: selectedSnapshot.settings.currentBalance,
+              currency: selectedSnapshot.currency,
+            },
+          ],
+        ])
 
-        setPersonalFinanceCards(cardsWithSummaries)
-        setPersonalFinanceSnapshot(selectedSnapshot)
-        setPersonalFinanceStatus('ready')
+        otherSnapshotResults.forEach((result, index) => {
+          if (result.status !== 'fulfilled') {
+            return
+          }
+
+          summaryByCardId.set(otherCards[index].id, {
+            currentBalance: result.value.settings.currentBalance,
+            currency: result.value.currency,
+          })
+        })
+
+        setPersonalFinanceCards(
+          cards.map((card): PersonalFinanceCardListItem => {
+            const summary = summaryByCardId.get(card.id)
+
+            return {
+              ...card,
+              currentBalance: summary?.currentBalance ?? null,
+              currency: summary?.currency ?? null,
+            }
+          }),
+        )
       } catch (error) {
         if (controller.signal.aborted) {
           return

--- a/frontend/src/features/personal-finance/PersonalFinanceView.tsx
+++ b/frontend/src/features/personal-finance/PersonalFinanceView.tsx
@@ -85,7 +85,7 @@ export function PersonalFinanceView({
 
   const hasCards = cards.length > 0
   const selectedCard = snapshot?.card ?? cards.find((card) => card.id === selectedCardId) ?? null
-  const yearOptions = selectableYearOptions()
+  const yearOptions = selectableYearOptions(year)
 
   return (
     <div className="space-y-6">
@@ -1437,9 +1437,8 @@ function currentMonthNumber(): number {
   return new Date().getMonth() + 1
 }
 
-function selectableYearOptions(): number[] {
-  const current = currentYear()
-  return Array.from({ length: 7 }, (_, index) => current - 3 + index)
+function selectableYearOptions(selectedYear: number): number[] {
+  return Array.from({ length: 7 }, (_, index) => selectedYear - 3 + index)
 }
 
 function serializeExpenseMonth(


### PR DESCRIPTION
## Summary
- rework personal finance shell with separate card, tab, and year panels
- move expense entry into a drawer and simplify the annual expenses table layout
- align card list behavior with account list and keep create-card flow in settings

## Testing
- npm --prefix frontend run lint
- npm --prefix frontend run build