### PR TITLE
Make personal finance pages full width and aggregate income/expenses

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -308,7 +308,7 @@ function App() {
           setSelectedPersonalFinanceCardId(resolvedCardId)
         }
 
-        const activeSnapshots = await Promise.all(
+        const activeSnapshotResults = await Promise.allSettled(
           activeCards.map((card) =>
             apiClient.getPersonalFinanceSnapshot(card.id, selectedPersonalFinanceYear, controller.signal),
           ),
@@ -318,25 +318,51 @@ function App() {
           return
         }
 
-        let settingsSnapshot =
-          activeSnapshots.find((snapshot) => snapshot.card.id === resolvedCardId) ?? null
+        const activeSnapshots = activeSnapshotResults.flatMap((result) =>
+          result.status === 'fulfilled' ? [result.value] : [],
+        )
+        const settingsCardId = resolvePersonalFinanceSettingsSelection(
+          cards,
+          resolvedCardId,
+          activeSnapshots,
+        )
 
-        if (!settingsSnapshot && resolvedCardId) {
-          settingsSnapshot = await apiClient.getPersonalFinanceSnapshot(
-            resolvedCardId,
-            selectedPersonalFinanceYear,
-            controller.signal,
-          )
+        if (settingsCardId !== selectedPersonalFinanceCardId) {
+          setSelectedPersonalFinanceCardId(settingsCardId)
+        }
+
+        let settingsSnapshot =
+          activeSnapshots.find((snapshot) => snapshot.card.id === settingsCardId) ?? null
+
+        if (!settingsSnapshot && settingsCardId) {
+          const settingsSnapshotResult = await Promise.allSettled([
+            apiClient.getPersonalFinanceSnapshot(
+              settingsCardId,
+              selectedPersonalFinanceYear,
+              controller.signal,
+            ),
+          ])
+          const fulfilledSettingsSnapshot = settingsSnapshotResult[0]
+          if (fulfilledSettingsSnapshot?.status === 'fulfilled') {
+            settingsSnapshot = fulfilledSettingsSnapshot.value
+          }
         }
 
         if (controller.signal.aborted) {
           return
         }
 
-        setActivePersonalFinanceSnapshots(activeSnapshots)
+        const mergedActiveSnapshots =
+          settingsSnapshot &&
+          settingsSnapshot.card.status === 'ACTIVE' &&
+          !activeSnapshots.some((snapshot) => snapshot.card.id === settingsSnapshot.card.id)
+            ? [...activeSnapshots, settingsSnapshot]
+            : activeSnapshots
+
+        setActivePersonalFinanceSnapshots(mergedActiveSnapshots)
         setSelectedPersonalFinanceSettingsSnapshot(settingsSnapshot)
         setPersonalFinanceCards(
-          enrichPersonalFinanceCards(cards, buildPersonalFinanceCardSummary(activeSnapshots, settingsSnapshot)),
+          enrichPersonalFinanceCards(cards, buildPersonalFinanceCardSummary(mergedActiveSnapshots, settingsSnapshot)),
         )
         setPersonalFinanceStatus('ready')
       } catch (error) {
@@ -1711,6 +1737,27 @@ function buildPersonalFinanceCardSummary(
   }
 
   return summaryByCardId
+}
+
+function resolvePersonalFinanceSettingsSelection(
+  cards: PersonalFinanceCardDto[],
+  resolvedCardId: string | null,
+  activeSnapshots: PersonalFinanceSnapshotDto[],
+): string | null {
+  const resolvedCard = cards.find((card) => card.id === resolvedCardId) ?? null
+  if (!resolvedCard) {
+    return activeSnapshots[0]?.card.id ?? cards[0]?.id ?? null
+  }
+
+  if (resolvedCard.status === 'ARCHIVED') {
+    return resolvedCard.id
+  }
+
+  if (activeSnapshots.some((snapshot) => snapshot.card.id === resolvedCard.id)) {
+    return resolvedCard.id
+  }
+
+  return activeSnapshots[0]?.card.id ?? resolvedCard.id
 }
 
 function getAccountCurrencyOptions(): string[] {

--- a/frontend/src/features/personal-finance/PersonalFinanceView.tsx
+++ b/frontend/src/features/personal-finance/PersonalFinanceView.tsx
@@ -181,12 +181,13 @@ export function PersonalFinanceView({
   const archivedCards = cards.filter((card) => card.status === 'ARCHIVED')
   const hasAnyCards = cards.length > 0
   const hasActiveCards = activeCards.length > 0
+  const hasLoadedActiveSnapshots = activeSnapshots.length > 0
   const selectedCard = settingsSnapshot?.card ?? cards.find((card) => card.id === selectedCardId) ?? null
   const activeTabCopy = PERSONAL_FINANCE_TAB_COPY[activeTab]
   const yearOptions = selectableYearOptions(year)
-  const canOpenActionPanel = activeTab === 'settings' || hasActiveCards
-  const aggregatedExpenses = hasActiveCards ? aggregateExpenses(activeSnapshots) : null
-  const aggregatedIncome = hasActiveCards ? aggregateIncome(activeSnapshots) : null
+  const canOpenActionPanel = activeTab === 'settings' || hasLoadedActiveSnapshots
+  const aggregatedExpenses = hasLoadedActiveSnapshots ? aggregateExpenses(activeSnapshots) : null
+  const aggregatedIncome = hasLoadedActiveSnapshots ? aggregateIncome(activeSnapshots) : null
 
   const handleTabSelect = (tab: PersonalFinanceTab): void => {
     setIsActionPanelOpen(false)
@@ -284,6 +285,13 @@ export function PersonalFinanceView({
       {activeTab === 'expenses' ? (
         aggregatedExpenses ? (
           <ExpensesTab key={`expenses-${year}-${activeCards.length}`} aggregate={aggregatedExpenses} />
+        ) : hasActiveCards ? (
+          <InlineStatus
+            tone="warning"
+            message="Не удалось полностью загрузить данные активных карт. Откройте настройки нужной карты или повторите попытку."
+            actionLabel="Повторить"
+            onAction={onRetry}
+          />
         ) : (
           <PersonalFinanceAggregateEmptyState
             tabLabel="расходов"
@@ -293,6 +301,13 @@ export function PersonalFinanceView({
       ) : activeTab === 'income' ? (
         aggregatedIncome ? (
           <IncomeTab key={`income-${year}-${activeCards.length}`} aggregate={aggregatedIncome} />
+        ) : hasActiveCards ? (
+          <InlineStatus
+            tone="warning"
+            message="Не удалось полностью загрузить данные активных карт. Откройте настройки нужной карты или повторите попытку."
+            actionLabel="Повторить"
+            onAction={onRetry}
+          />
         ) : (
           <PersonalFinanceAggregateEmptyState
             tabLabel="доходов"
@@ -321,7 +336,7 @@ export function PersonalFinanceView({
           description={activeTabCopy.panelDescription}
           onClose={() => setIsActionPanelOpen(false)}
         >
-          {activeTab === 'expenses' && hasActiveCards ? (
+          {activeTab === 'expenses' && hasLoadedActiveSnapshots ? (
             <ExpenseEntryDrawerPanel
               activeSnapshots={activeSnapshots}
               preferredCardId={selectedCardId}
@@ -329,7 +344,7 @@ export function PersonalFinanceView({
               onClose={() => setIsActionPanelOpen(false)}
             />
           ) : null}
-          {activeTab === 'income' && hasActiveCards ? (
+          {activeTab === 'income' && hasLoadedActiveSnapshots ? (
             <IncomeEntryDrawerPanel
               activeSnapshots={activeSnapshots}
               preferredCardId={selectedCardId}


### PR DESCRIPTION
## Summary
- make the main app shell full width instead of constraining dashboard/accounts/personal-finance to a narrow max width
- aggregate personal-finance income and expense tabs across all active cards on the frontend
- keep settings card-scoped and require explicit card selection when adding income or expenses

## Testing
- npm -C frontend run build