### PR TITLE
feat(accounts): account editing vertical slice

### DIFF
--- a/backend/api/src/main/java/com/mindfulfinance/api/AccountsController.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/AccountsController.java
@@ -33,6 +33,7 @@ import com.mindfulfinance.application.usecases.ComputeMonthlySavingsByCurrency;
 import com.mindfulfinance.application.usecases.ComputeNetWorthByCurrency;
 import com.mindfulfinance.application.usecases.DeleteTransaction;
 import com.mindfulfinance.application.usecases.ImportTransactions;
+import com.mindfulfinance.application.usecases.UpdateAccount;
 import com.mindfulfinance.application.usecases.UpdateTransaction;
 import com.mindfulfinance.domain.account.Account;
 import com.mindfulfinance.domain.account.AccountId;
@@ -55,6 +56,7 @@ public class AccountsController {
     private final ComputeNetWorthByCurrency computeNetWorthByCurrency;
     private final ImportTransactions importTransactions;
     private final DeleteTransaction deleteTransactionUseCase;
+    private final UpdateAccount updateAccount;
     private final UpdateTransaction updateTransaction;
 
     public AccountsController(
@@ -67,6 +69,7 @@ public class AccountsController {
         ComputeNetWorthByCurrency computeNetWorthByCurrency,
         ImportTransactions importTransactions,
         DeleteTransaction deleteTransactionUseCase,
+        UpdateAccount updateAccount,
         UpdateTransaction updateTransaction
     ) {
         this.accountRepository = accountRepository;
@@ -78,6 +81,7 @@ public class AccountsController {
         this.computeNetWorthByCurrency = computeNetWorthByCurrency;
         this.importTransactions = importTransactions;
         this.deleteTransactionUseCase = deleteTransactionUseCase;
+        this.updateAccount = updateAccount;
         this.updateTransaction = updateTransaction;
     }
 
@@ -102,6 +106,30 @@ public class AccountsController {
                 account.status().name()
             ))
             .toList();
+    }
+
+    @PutMapping("/accounts/{accountId}")
+    public ResponseEntity<Void> updateAccount(
+        @PathVariable("accountId") String accountId,
+        @RequestBody UpdateAccountRequest req
+    ) {
+        AccountId parsedAccountId = parseAccountId(accountId);
+        requireInvestmentAccount(parsedAccountId);
+        if (req == null) {
+            throw new IllegalArgumentException("Request body must not be null");
+        }
+
+        boolean updated = updateAccount.update(new UpdateAccount.Command(
+            parsedAccountId,
+            req.name(),
+            parseAccountType(req.type())
+        )).isPresent();
+
+        if (!updated) {
+            throw new AccountNotFoundException("Account not found");
+        }
+
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/accounts/{accountId}/transactions")
@@ -287,6 +315,19 @@ public class AccountsController {
         return new TransactionId(UUID.fromString(transactionId));
     }
 
+    private static AccountType parseAccountType(String rawType) {
+        String trimmed = rawType == null ? "" : rawType.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("type must not be blank");
+        }
+
+        try {
+            return AccountType.valueOf(trimmed.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Unsupported account type: " + rawType);
+        }
+    }
+
     private static LocalDate parseAsOfDate(String asOf) {
         if (asOf == null || asOf.isBlank()) return LocalDate.now();
         try {
@@ -304,6 +345,8 @@ public class AccountsController {
     }
 
     public record CreateAccountResponse(String accountId) {}
+
+    public record UpdateAccountRequest(String name, String type) {}
 
     public record AccountDto(
         String id,

--- a/backend/api/src/main/java/com/mindfulfinance/api/config/ApiWiringConfig.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/config/ApiWiringConfig.java
@@ -42,6 +42,7 @@ import com.mindfulfinance.application.usecases.SaveMonthlyExpenseActual;
 import com.mindfulfinance.application.usecases.SaveMonthlyExpenseLimit;
 import com.mindfulfinance.application.usecases.SaveMonthlyIncomeActual;
 import com.mindfulfinance.application.usecases.SavePersonalFinanceSettings;
+import com.mindfulfinance.application.usecases.UpdateAccount;
 import com.mindfulfinance.application.usecases.UpdateTransaction;
 import com.mindfulfinance.postgres.PostgresAccountRepository;
 import com.mindfulfinance.postgres.PostgresIncomeForecastRepository;
@@ -185,6 +186,11 @@ public class ApiWiringConfig {
     @Bean
     public ImportTransactions importTransactions(AccountRepository accountRepository, TransactionRepository transactionRepository) {
         return new ImportTransactions(accountRepository, transactionRepository);
+    }
+
+    @Bean
+    public UpdateAccount updateAccount(AccountRepository accountRepository) {
+        return new UpdateAccount(accountRepository);
     }
 
     @Bean

--- a/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerPostgresIntegrationTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerPostgresIntegrationTest.java
@@ -93,6 +93,29 @@ public class AccountsControllerPostgresIntegrationTest {
     }
 
     @Test
+    public void update_account_endpoint_updates_name_and_type_and_keeps_currency_with_postgres_profile() throws Exception {
+        MvcResult accountResult = mockMvc.perform(post("/accounts")
+            .contentType("application/json")
+            .content("{\"name\":\"Cash\",\"currency\":\"USD\",\"type\":\"CASH\"}"))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        String accountId = JsonPath.read(accountResult.getResponse().getContentAsString(), "$.accountId");
+
+        mockMvc.perform(put("/accounts/{accountId}", accountId)
+            .contentType("application/json")
+            .content("{\"name\":\"Main Brokerage\",\"type\":\"BROKERAGE\"}"))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/accounts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(accountId))
+            .andExpect(jsonPath("$[0].name").value("Main Brokerage"))
+            .andExpect(jsonPath("$[0].type").value("BROKERAGE"))
+            .andExpect(jsonPath("$[0].currency").value("USD"));
+    }
+
+    @Test
     public void update_transaction_endpoint_updates_list_balance_and_metrics_with_postgres_profile() throws Exception {
         MvcResult accountResult = mockMvc.perform(post("/accounts")
             .contentType("application/json")

--- a/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerTest.java
@@ -62,6 +62,69 @@ public class AccountsControllerTest {
     }
 
     @Test
+    public void updateAccount_updatesNameAndType_andKeepsCurrencyImmutable() throws Exception {
+        String accountId = JsonPath.read(mockMvc.perform(post("/accounts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Cash\",\"currency\":\"USD\",\"type\":\"CASH\"}"))
+            .andExpect(status().isCreated())
+            .andReturn().getResponse().getContentAsString(), "$.accountId");
+
+        mockMvc.perform(put("/accounts/{accountId}", accountId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Main Brokerage\",\"type\":\"BROKERAGE\"}"))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/accounts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(accountId))
+            .andExpect(jsonPath("$[0].name").value("Main Brokerage"))
+            .andExpect(jsonPath("$[0].type").value("BROKERAGE"))
+            .andExpect(jsonPath("$[0].currency").value("USD"));
+    }
+
+    @Test
+    public void updateAccount_forMissingAccount_returns404() throws Exception {
+        String missingAccountId = UUID.randomUUID().toString();
+
+        mockMvc.perform(put("/accounts/{accountId}", missingAccountId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Main Brokerage\",\"type\":\"BROKERAGE\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+    }
+
+    @Test
+    public void updateAccount_withBlankName_returns400() throws Exception {
+        String accountId = JsonPath.read(mockMvc.perform(post("/accounts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Cash\",\"currency\":\"USD\",\"type\":\"CASH\"}"))
+            .andExpect(status().isCreated())
+            .andReturn().getResponse().getContentAsString(), "$.accountId");
+
+        mockMvc.perform(put("/accounts/{accountId}", accountId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"   \",\"type\":\"BROKERAGE\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("BAD_REQUEST"));
+    }
+
+    @Test
+    public void updateAccount_withInvalidType_returns400() throws Exception {
+        String accountId = JsonPath.read(mockMvc.perform(post("/accounts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Cash\",\"currency\":\"USD\",\"type\":\"CASH\"}"))
+            .andExpect(status().isCreated())
+            .andReturn().getResponse().getContentAsString(), "$.accountId");
+
+        mockMvc.perform(put("/accounts/{accountId}", accountId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Main\",\"type\":\"CRYPTO\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("Unsupported account type: CRYPTO"));
+    }
+
+    @Test
     public void createAndListTransactions_forExistingAccount() throws Exception {
         MvcResult accountResult = mockMvc.perform(post("/accounts")
             .contentType(MediaType.APPLICATION_JSON)
@@ -396,6 +459,12 @@ public class AccountsControllerTest {
             .andExpect(jsonPath("$.error").value("NOT_FOUND"));
 
         mockMvc.perform(get("/accounts/{accountId}/transactions", linkedAccountId))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+
+        mockMvc.perform(put("/accounts/{accountId}", linkedAccountId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"Новое имя\",\"type\":\"BROKERAGE\"}"))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.error").value("NOT_FOUND"));
 

--- a/backend/application/src/main/java/com/mindfulfinance/application/usecases/UpdateAccount.java
+++ b/backend/application/src/main/java/com/mindfulfinance/application/usecases/UpdateAccount.java
@@ -1,0 +1,43 @@
+package com.mindfulfinance.application.usecases;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.mindfulfinance.application.ports.AccountRepository;
+import com.mindfulfinance.domain.account.Account;
+import com.mindfulfinance.domain.account.AccountId;
+import com.mindfulfinance.domain.account.AccountType;
+
+public final class UpdateAccount {
+    private final AccountRepository accounts;
+
+    public UpdateAccount(AccountRepository accounts) {
+        this.accounts = accounts;
+    }
+
+    public Optional<Account> update(Command command) {
+        Objects.requireNonNull(command, "command");
+
+        Account existingAccount = accounts.find(command.accountId()).orElse(null);
+        if (existingAccount == null) {
+            return Optional.empty();
+        }
+
+        Account updatedAccount = new Account(
+            existingAccount.id(),
+            command.name(),
+            existingAccount.currency(),
+            command.type(),
+            existingAccount.status(),
+            existingAccount.createdAt()
+        );
+        accounts.save(updatedAccount);
+        return Optional.of(updatedAccount);
+    }
+
+    public record Command(
+        AccountId accountId,
+        String name,
+        AccountType type
+    ) {}
+}

--- a/backend/application/src/test/java/com/mindfulfinance/application/usecases/UpdateAccountTest.java
+++ b/backend/application/src/test/java/com/mindfulfinance/application/usecases/UpdateAccountTest.java
@@ -1,0 +1,90 @@
+package com.mindfulfinance.application.usecases;
+
+import java.time.Instant;
+import java.util.Currency;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.mindfulfinance.application.ports.InMemoryAccountRepository;
+import com.mindfulfinance.domain.account.Account;
+import com.mindfulfinance.domain.account.AccountId;
+import com.mindfulfinance.domain.account.AccountType;
+import com.mindfulfinance.domain.shared.DomainException;
+
+import static com.mindfulfinance.domain.account.AccountStatus.ACTIVE;
+import static com.mindfulfinance.domain.account.AccountType.BROKERAGE;
+import static com.mindfulfinance.domain.account.AccountType.CASH;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.ACCOUNT_NAME_NULL_OR_BLANK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UpdateAccountTest {
+    private final InMemoryAccountRepository accounts = new InMemoryAccountRepository();
+    private final UpdateAccount useCase = new UpdateAccount(accounts);
+
+    @Test
+    @DisplayName("Should update account name and type while preserving immutable fields")
+    void shouldUpdateAccountNameAndTypeWhilePreservingImmutableFields() {
+        AccountId accountId = AccountId.random();
+        Account existing = new Account(
+            accountId,
+            "Cash",
+            Currency.getInstance("USD"),
+            CASH,
+            ACTIVE,
+            Instant.parse("2026-03-01T10:15:30Z")
+        );
+        accounts.save(existing);
+
+        Optional<Account> updated = useCase.update(new UpdateAccount.Command(
+            accountId,
+            "  Main Brokerage  ",
+            BROKERAGE
+        ));
+
+        assertTrue(updated.isPresent());
+        assertEquals(accountId, updated.get().id());
+        assertEquals("Main Brokerage", updated.get().name());
+        assertEquals(Currency.getInstance("USD"), updated.get().currency());
+        assertEquals(BROKERAGE, updated.get().type());
+        assertEquals(ACTIVE, updated.get().status());
+        assertEquals(Instant.parse("2026-03-01T10:15:30Z"), updated.get().createdAt());
+        assertEquals(updated.get(), accounts.find(accountId).orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Should return empty when account does not exist")
+    void shouldReturnEmptyWhenAccountDoesNotExist() {
+        Optional<Account> updated = useCase.update(new UpdateAccount.Command(
+            AccountId.random(),
+            "Main Brokerage",
+            AccountType.BROKERAGE
+        ));
+
+        assertTrue(updated.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should reject blank account name")
+    void shouldRejectBlankAccountName() {
+        AccountId accountId = AccountId.random();
+        accounts.save(new Account(
+            accountId,
+            "Cash",
+            Currency.getInstance("USD"),
+            CASH,
+            ACTIVE,
+            Instant.parse("2026-03-01T10:15:30Z")
+        ));
+
+        DomainException exception = assertThrows(
+            DomainException.class,
+            () -> useCase.update(new UpdateAccount.Command(accountId, "   ", BROKERAGE))
+        );
+
+        assertEquals(ACCOUNT_NAME_NULL_OR_BLANK, exception.code());
+    }
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -33,5 +33,6 @@ Covered read endpoints:
 Covered write endpoints:
 
 - `POST /accounts`
+- `PUT /accounts/{accountId}`
 - `POST /accounts/{accountId}/transactions`
 - `POST /imports/transactions/csv` (multipart form data: `accountId` + `file`)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import {
   type PersonalFinanceSnapshotDto,
   type TransactionDirection,
   type TransactionDto,
+  type UpdateAccountRequest,
   type UpdateMonthlyExpenseRequest,
   type UpdateMonthlyIncomeActualRequest,
   type UpdatePersonalFinanceCardRequest,
@@ -455,6 +456,14 @@ function App() {
     }
   }
 
+  const handleUpdateAccount = async (
+    accountId: string,
+    request: UpdateAccountRequest,
+  ): Promise<void> => {
+    await apiClient.updateAccount(accountId, request)
+    setAccountsReloadTick((tick) => tick + 1)
+  }
+
   const refreshTransactionDerivedViews = (): void => {
     setTransactionsReloadTick((tick) => tick + 1)
     setAccountsReloadTick((tick) => tick + 1)
@@ -737,6 +746,7 @@ function App() {
               createAccountStatus={createAccountStatus}
               createAccountErrorMessage={createAccountErrorMessage}
               onCreateAccount={handleCreateAccount}
+              onUpdateAccount={handleUpdateAccount}
               createTransactionStatus={createTransactionStatus}
               createTransactionErrorMessage={createTransactionErrorMessage}
               onCreateTransaction={handleCreateTransaction}
@@ -829,6 +839,7 @@ interface AccountsViewProps {
   createAccountStatus: CreateAccountStatus
   createAccountErrorMessage: string | null
   onCreateAccount: (request: CreateAccountRequest) => Promise<boolean>
+  onUpdateAccount: (accountId: string, request: UpdateAccountRequest) => Promise<void>
   createTransactionStatus: CreateTransactionStatus
   createTransactionErrorMessage: string | null
   onCreateTransaction: (accountId: string, request: CreateTransactionRequest) => Promise<boolean>
@@ -864,6 +875,7 @@ function AccountsView({
   createAccountStatus,
   createAccountErrorMessage,
   onCreateAccount,
+  onUpdateAccount,
   createTransactionStatus,
   createTransactionErrorMessage,
   onCreateTransaction,
@@ -880,6 +892,11 @@ function AccountsView({
   const [newAccountName, setNewAccountName] = useState<string>('')
   const [newAccountCurrency, setNewAccountCurrency] = useState<string>(DEFAULT_ACCOUNT_CURRENCY)
   const [newAccountType, setNewAccountType] = useState<AccountType>('CASH')
+  const [editingAccountId, setEditingAccountId] = useState<string | null>(null)
+  const [editingAccountName, setEditingAccountName] = useState<string>('')
+  const [editingAccountType, setEditingAccountType] = useState<AccountType>('CASH')
+  const [updateAccountStatus, setUpdateAccountStatus] = useState<CreateAccountStatus>('idle')
+  const [updateAccountErrorMessage, setUpdateAccountErrorMessage] = useState<string | null>(null)
   const [newTransactionDate, setNewTransactionDate] = useState<string>(todayIsoDate())
   const [newTransactionDirection, setNewTransactionDirection] = useState<TransactionDirection>('OUTFLOW')
   const [newTransactionAmount, setNewTransactionAmount] = useState<string>('')
@@ -897,6 +914,14 @@ function AccountsView({
   const [deleteTransactionErrorMessage, setDeleteTransactionErrorMessage] = useState<string | null>(null)
   const [csvFile, setCsvFile] = useState<File | null>(null)
   const csvFileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const resetEditingAccount = (): void => {
+    setEditingAccountId(null)
+    setEditingAccountName('')
+    setEditingAccountType('CASH')
+    setUpdateAccountStatus('idle')
+    setUpdateAccountErrorMessage(null)
+  }
 
   const resetEditingTransaction = (): void => {
     setEditingTransactionAccountId(null)
@@ -932,6 +957,12 @@ function AccountsView({
   const isCurrencyValid = ACCOUNT_CURRENCY_OPTIONS.includes(newAccountCurrency)
   const canCreate =
     newAccountName.trim().length > 0 && isCurrencyValid && createAccountStatus !== 'submitting'
+  const isEditingSelectedAccount =
+    selectedAccount !== null && editingAccountId === selectedAccount.id
+  const canUpdateAccount =
+    isEditingSelectedAccount &&
+    editingAccountName.trim().length > 0 &&
+    updateAccountStatus !== 'submitting'
 
   const transactionDateCandidate = newTransactionDate.trim()
   const transactionAmountCandidate = normalizeAmountInput(newTransactionAmount)
@@ -978,6 +1009,40 @@ function AccountsView({
 
     if (created) {
       setNewAccountName('')
+    }
+  }
+
+  const handleStartEditingAccount = (): void => {
+    if (!selectedAccount) {
+      return
+    }
+
+    setEditingAccountId(selectedAccount.id)
+    setEditingAccountName(selectedAccount.name)
+    setEditingAccountType(selectedAccount.type)
+    setUpdateAccountStatus('idle')
+    setUpdateAccountErrorMessage(null)
+  }
+
+  const handleUpdateAccountSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault()
+
+    if (!selectedAccount || !isEditingSelectedAccount || !canUpdateAccount) {
+      return
+    }
+
+    setUpdateAccountStatus('submitting')
+    setUpdateAccountErrorMessage(null)
+
+    try {
+      await onUpdateAccount(selectedAccount.id, {
+        name: editingAccountName.trim(),
+        type: editingAccountType,
+      })
+      resetEditingAccount()
+    } catch (error) {
+      setUpdateAccountStatus('error')
+      setUpdateAccountErrorMessage(toErrorMessage(error))
     }
   }
 
@@ -1077,6 +1142,7 @@ function AccountsView({
 
   const handleSelectAccountClick = (accountId: string): void => {
     onSelectAccount(accountId)
+    resetEditingAccount()
     resetEditingTransaction()
     resetDeleteTransactionState()
     setNewTransactionDate(todayIsoDate())
@@ -1208,7 +1274,85 @@ function AccountsView({
                   Транзакции · {selectedAccount.balance.currency}
                 </p>
               </div>
+              {!isEditingSelectedAccount ? (
+                <button
+                  type="button"
+                  onClick={handleStartEditingAccount}
+                  className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800"
+                >
+                  Редактировать счет
+                </button>
+              ) : null}
             </div>
+
+            {isEditingSelectedAccount ? (
+              <form
+                className="mt-4 rounded-lg border border-slate-200 bg-white p-3"
+                onSubmit={(event) => {
+                  void handleUpdateAccountSubmit(event)
+                }}
+              >
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  Редактировать счет
+                </p>
+
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <label className="text-xs text-slate-600">
+                    Название
+                    <input
+                      type="text"
+                      value={editingAccountName}
+                      onChange={(event) => setEditingAccountName(event.target.value)}
+                      className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+                    />
+                  </label>
+
+                  <label className="text-xs text-slate-600">
+                    Тип
+                    <select
+                      value={editingAccountType}
+                      onChange={(event) => setEditingAccountType(event.target.value as AccountType)}
+                      className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+                    >
+                      {ACCOUNT_TYPE_OPTIONS.map((type) => (
+                        <option key={type} value={type}>
+                          {toAccountTypeLabel(type)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+
+                <p className="mt-2 text-xs text-slate-500">
+                  Валюта счета фиксируется при создании и не редактируется: {selectedAccount.currency}.
+                </p>
+
+                {updateAccountStatus === 'error' && updateAccountErrorMessage ? (
+                  <p className="mt-2 text-xs text-amber-700">{updateAccountErrorMessage}</p>
+                ) : null}
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="submit"
+                    disabled={!canUpdateAccount}
+                    className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {updateAccountStatus === 'submitting' ? 'Сохраняем...' : 'Сохранить'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resetEditingAccount}
+                    className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600"
+                  >
+                    Отмена
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <p className="mt-2 text-xs text-slate-500">
+                Валюта счета фиксируется при создании и не редактируется.
+              </p>
+            )}
 
             <form
               className="mt-4 rounded-lg border border-slate-200 bg-white p-3"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,7 @@ import type {
   TransactionDto,
   UpdateMonthlyExpenseRequest,
   UpdateMonthlyIncomeActualRequest,
+  UpdateAccountRequest,
   UpdatePersonalFinanceCardRequest,
   UpdatePersonalFinanceSettingsRequest,
   UpdateTransactionRequest,
@@ -23,6 +24,7 @@ import type {
 
 export interface ApiClient {
   createAccount(request: CreateAccountRequest, signal?: AbortSignal): Promise<CreateAccountResponse>
+  updateAccount(accountId: string, request: UpdateAccountRequest, signal?: AbortSignal): Promise<void>
   createTransaction(
     accountId: string,
     request: CreateTransactionRequest,
@@ -89,6 +91,16 @@ export function createApiClient(config: HttpClientConfig = {}): ApiClient {
   return {
     createAccount(request: CreateAccountRequest, signal?: AbortSignal): Promise<CreateAccountResponse> {
       return http.postJson<CreateAccountResponse, CreateAccountRequest>('/accounts', request, { signal })
+    },
+
+    updateAccount(
+      accountId: string,
+      request: UpdateAccountRequest,
+      signal?: AbortSignal,
+    ): Promise<void> {
+      return http.putJson<void, UpdateAccountRequest>(`/accounts/${toEncodedAccountId(accountId)}`, request, {
+        signal,
+      })
     },
 
     createTransaction(

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -18,6 +18,7 @@ export type {
   CreatePersonalFinanceCardResponse,
   CreateAccountRequest,
   CreateAccountResponse,
+  UpdateAccountRequest,
   CreateTransactionRequest,
   CreateTransactionResponse,
   DecimalAmount,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -22,6 +22,11 @@ export interface CreateAccountResponse {
   accountId: string
 }
 
+export interface UpdateAccountRequest {
+  name: string
+  type: AccountType
+}
+
 export type TransactionDirection = 'INFLOW' | 'OUTFLOW'
 
 export interface CreateTransactionRequest {


### PR DESCRIPTION
## Summary
- add UpdateAccount use case to update editable account fields (name, type)
- add PUT /accounts/{accountId} with 204/404/400 behavior and preserve immutable fields
- add and extend unit, WebMvc, and Postgres integration tests for account update flows
- add frontend API method and inline account edit form in the right panel
- document new write endpoint in frontend README

## Constraints
- immutable fields stay immutable in v1: id, currency, status, createdAt
- linked personal-finance accounts remain unavailable in account endpoints and return 404

## Verification
- mvn -f backend/pom.xml -Dtest=UpdateAccountTest,AccountsControllerTest,AccountsControllerPostgresIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -f backend/pom.xml test
- npm -C frontend run build

Closes #17