### PR TITLE
Personal finance UI: swap Investments and Education order

### DIFF
--- a/backend/api/src/test/java/com/mindfulfinance/api/PersonalFinanceControllerPostgresIntegrationTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/PersonalFinanceControllerPostgresIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.mindfulfinance.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -76,9 +77,9 @@ public class PersonalFinanceControllerPostgresIntegrationTest {
             .andExpect(jsonPath("$.categories", hasSize(9)))
             .andExpect(jsonPath("$.categories[0].limitPeriod").value("MONTHLY"))
             .andExpect(jsonPath("$.categories[0].classification").value("EXPENSE"))
-            .andExpect(jsonPath("$.categories[6].limitPeriod").value("ANNUAL"))
-            .andExpect(jsonPath("$.categories[6].classification").value("TRANSFER"))
-            .andExpect(jsonPath("$.categories[7].limitPeriod").value("ANNUAL"))
+            .andExpect(jsonPath("$.categories[?(@.code=='INVESTMENTS')].limitPeriod").value(hasItem("ANNUAL")))
+            .andExpect(jsonPath("$.categories[?(@.code=='INVESTMENTS')].classification").value(hasItem("TRANSFER")))
+            .andExpect(jsonPath("$.categories[?(@.code=='EDUCATION')].limitPeriod").value(hasItem("ANNUAL")))
             .andExpect(jsonPath("$.expenses.months", hasSize(12)))
             .andExpect(jsonPath("$.income.months", hasSize(12)))
             .andExpect(jsonPath("$.expenses.annualActualTotal").value("0.00"))
@@ -194,8 +195,8 @@ public class PersonalFinanceControllerPostgresIntegrationTest {
 
         mockMvc.perform(get("/personal-finance/cards/{cardId}/years/2026", cardId))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.categories[6].limitPeriod").value("ANNUAL"))
-            .andExpect(jsonPath("$.categories[6].classification").value("TRANSFER"))
+            .andExpect(jsonPath("$.categories[?(@.code=='INVESTMENTS')].limitPeriod").value(hasItem("ANNUAL")))
+            .andExpect(jsonPath("$.categories[?(@.code=='INVESTMENTS')].classification").value(hasItem("TRANSFER")))
             .andExpect(jsonPath("$.expenses.months[1].actualCategoryAmounts.INVESTMENTS").value("200.00"))
             .andExpect(jsonPath("$.expenses.months[1].actualTotal").value("100.00"))
             .andExpect(jsonPath("$.expenses.months[1].limitTotal").value("0.00"))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -329,10 +329,11 @@ function App() {
         const activeSnapshots = activeSnapshotResults.flatMap((result) =>
           result.status === 'fulfilled' ? [result.value] : [],
         )
+        const normalizedActiveSnapshots = activeSnapshots.map(normalizePersonalFinanceSnapshotCategoryOrder)
         const settingsCardId = resolvePersonalFinanceSettingsSelection(
           cards,
           resolvedCardId,
-          activeSnapshots,
+          normalizedActiveSnapshots,
         )
 
         if (settingsCardId !== selectedPersonalFinanceCardId) {
@@ -340,7 +341,7 @@ function App() {
         }
 
         let settingsSnapshot =
-          activeSnapshots.find((snapshot) => snapshot.card.id === settingsCardId) ?? null
+          normalizedActiveSnapshots.find((snapshot) => snapshot.card.id === settingsCardId) ?? null
 
         if (!settingsSnapshot && settingsCardId) {
           const settingsSnapshotResult = await Promise.allSettled([
@@ -352,7 +353,7 @@ function App() {
           ])
           const fulfilledSettingsSnapshot = settingsSnapshotResult[0]
           if (fulfilledSettingsSnapshot?.status === 'fulfilled') {
-            settingsSnapshot = fulfilledSettingsSnapshot.value
+            settingsSnapshot = normalizePersonalFinanceSnapshotCategoryOrder(fulfilledSettingsSnapshot.value)
           }
         }
 
@@ -363,9 +364,9 @@ function App() {
         const mergedActiveSnapshots =
           settingsSnapshot &&
           settingsSnapshot.card.status === 'ACTIVE' &&
-          !activeSnapshots.some((snapshot) => snapshot.card.id === settingsSnapshot.card.id)
-            ? [...activeSnapshots, settingsSnapshot]
-            : activeSnapshots
+          !normalizedActiveSnapshots.some((snapshot) => snapshot.card.id === settingsSnapshot.card.id)
+            ? [...normalizedActiveSnapshots, settingsSnapshot]
+            : normalizedActiveSnapshots
 
         setActivePersonalFinanceSnapshots(mergedActiveSnapshots)
         setSelectedPersonalFinanceSettingsSnapshot(settingsSnapshot)
@@ -2005,6 +2006,38 @@ function toAccountStatusLabel(status: AccountStatus): string {
     return 'Архивный'
   }
   return status
+}
+
+function normalizePersonalFinanceSnapshotCategoryOrder(
+  snapshot: PersonalFinanceSnapshotDto,
+): PersonalFinanceSnapshotDto {
+  const categories = swapEducationAndInvestments(snapshot.categories)
+  if (categories === snapshot.categories) {
+    return snapshot
+  }
+
+  return {
+    ...snapshot,
+    categories,
+  }
+}
+
+function swapEducationAndInvestments(
+  categories: PersonalFinanceSnapshotDto['categories'],
+): PersonalFinanceSnapshotDto['categories'] {
+  const investmentsIndex = categories.findIndex((category) => category.code === 'INVESTMENTS')
+  const educationIndex = categories.findIndex((category) => category.code === 'EDUCATION')
+
+  if (investmentsIndex < 0 || educationIndex < 0 || investmentsIndex === educationIndex) {
+    return categories
+  }
+
+  const reorderedCategories = [...categories]
+  ;[reorderedCategories[investmentsIndex], reorderedCategories[educationIndex]] = [
+    reorderedCategories[educationIndex],
+    reorderedCategories[investmentsIndex],
+  ]
+  return reorderedCategories
 }
 
 function enrichPersonalFinanceCards(


### PR DESCRIPTION
## Summary
- swap EDUCATION and INVESTMENTS order in personal-finance UI rendering only
- keep API/persistence semantics unchanged
- harden backend regression assertions to verify INVESTMENTS semantics by category code

## Validation
- mvn -f backend/pom.xml test
- npm -C frontend run build

Closes #101
