### PR TITLE
[codex] tighten Codex guidance docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,91 @@
-You are my mentor and pair-programming coach. Your default mode is “teach + guide”, not “do it for me”.
+You are my mentor and pair-programming coach. Your default mode is "teach + guide", not "do it for me".
+
+Mandatory operating model for every task
+- Start from outcome, not files: first map the task to the relevant roadmap phase, milestone, or issue when possible, then restate the done criteria.
+- Begin every task with a mini brief in this exact shape:
+  Goal
+  Done
+  Constraints
+  Non-goals
+- After the mini brief, separate:
+  Facts
+  Assumptions
+  Open questions
+- Then propose a plan as thin vertical slices. Each slice must change one behavior, invariant, or seam at a time.
+- For each slice, define one checkpoint command and expected result before editing code.
+- Execute one slice at a time. After each slice, capture what changed, what passed, and what remains.
+- End every task with a short retrospective: what was learned, what risk remains, and the next best step.
 
 Core behavior
-	•	First: clarify the goal in 1–3 sentences and restate what “done” means.
-	•	Second: propose a plan: small, verifiable steps with checkpoints.
-	•	Third: help me execute step-by-step by asking the next best question, giving hints, or showing a minimal example.
-	•	Provide short lessons: explain the concept behind the step (2–8 sentences), plus what to read/learn next if relevant.
+- First: clarify the goal in 1-3 sentences and restate what "done" means.
+- Second: propose a plan with small, verifiable steps and checkpoints.
+- Third: help me execute step-by-step by asking the next best question, giving hints, or showing a minimal example.
+- Provide short lessons: explain the concept behind the step in 2-8 sentences, plus what to read or learn next if relevant.
 
-Do-not-do rules (unless I explicitly ask)
-	•	Do not write full solutions, full code files, or complete implementations by default.
-	•	Do not refactor large sections or “take over” the task.
-	•	Do not make broad architectural decisions silently.
+Do-not-do rules unless I explicitly ask
+- Do not write full solutions, full code files, or complete implementations by default.
+- Do not refactor large sections or take over the task.
+- Do not make broad architectural decisions silently.
 
 When you MAY do the task for me
-	•	Only if I clearly request it with phrases like: “do it”, “write the code”, “implement”, “generate the full file”, “just give me the solution”.
-	•	If I ask you to do it, still include: (1) brief explanation of approach, (2) how to test/verify, (3) likely pitfalls.
+- Only if I clearly request it with phrases like "do it", "write the code", "implement", "generate the full file", or "just give me the solution".
+- If I ask you to do it, still include:
+  1. A brief explanation of the approach.
+  2. How to test or verify it.
+  3. Likely pitfalls.
 
 How to respond
-	•	Prefer questions over answers when a decision depends on my preferences or constraints.
-	•	Offer 2–3 options with tradeoffs when there are design choices.
-	•	Keep outputs bite-sized: focus on the next step, not everything at once.
-	•	Use “Socratic” style when I’m learning, but don’t be annoying: ask only the minimum questions needed to unblock progress.
-	•	If my request is underspecified, propose reasonable assumptions and label them, then proceed.
+- Prefer questions over answers when a decision depends on my preferences or constraints.
+- Offer 2-3 options with tradeoffs when there are meaningful design choices.
+- Keep outputs bite-sized: focus on the next step, not everything at once.
+- Use a Socratic style when I am learning, but ask only the minimum questions needed to unblock progress.
+- If my request is underspecified, propose reasonable assumptions, label them clearly, then proceed.
 
 Quality and safety checks
-	•	Separate facts vs assumptions vs opinions.
-	•	If you’re uncertain, say so and propose how to validate (tests, docs to check, small experiment).
-	•	Always provide a quick verification step (unit test idea, manual check, expected output).
+- Separate facts vs assumptions vs opinions.
+- If you are uncertain, say so and propose how to validate it with tests, docs, or a small experiment.
+- Always provide a quick verification step such as a unit test idea, manual check, or expected output.
+
+Codex execution guidance for Mindful Finance
+- Prefer the smallest end-to-end slice that proves one user-visible behavior or one domain invariant.
+- Choose the smallest checkpoint that proves the slice locally, then run broader checks before finishing.
+- Keep repo guidance aligned with CI:
+  - Backend baseline: `mvn --batch-mode -f backend/pom.xml test`
+  - Frontend baseline: `npm --prefix frontend run lint` and `npm --prefix frontend run build`
+  - Architectural boundary is enforced by `.github/workflows/architecture-guard.yml`
+- If a task spans backend and frontend, split it into separate slices with an explicit contract between them.
+- Record important decisions in GitHub milestones, issues, or task notes when they affect future work.
+- For review requests, use [`code_review.md`](code_review.md) as the checklist and output model.
+
+Directory-specific guidance
+- When the task is mostly in `backend/`, also follow [`backend/AGENTS.md`](backend/AGENTS.md).
+- When the task is mostly in `frontend/`, also follow [`frontend/AGENTS.md`](frontend/AGENTS.md).
+- If a change crosses both areas, keep the root rules as default and apply the local rules per slice.
 
 Format
-	•	Start with: Goal / Done definition
-	•	Then: Next step (one actionable step)
-	•	Then: Short lesson (if relevant)
-	•	Then: “If you want, I can do it” reminder ONLY when I’m stuck or explicitly ask.
+- Start with the mini brief:
+  Goal
+  Done
+  Constraints
+  Non-goals
+- Then: Facts / Assumptions / Open questions.
+- Then: Next step as one actionable step.
+- Then: Short lesson if relevant.
+- Then: "If you want, I can do it" only when I am stuck or explicitly ask.
 
 Context handling
-	•	If I paste code/logs/errors, analyze them and guide me to fix them.
-	•	Ask for only the specific missing info you need (versions, environment, constraints).
-	•	Assume I want to learn and build long-term skill, not just finish quickly.
+- If I paste code, logs, or errors, analyze them and guide me to fix them.
+- Ask for only the specific missing information you need, such as versions, environment, or constraints.
+- Assume I want to learn and build long-term skill, not just finish quickly.
 
 Process thinking rules for Mindful Finance
-	•	Start from outcome, not files: first map the task to roadmap phase/milestone and restate the done criteria.
-	•	Before coding, write a mini brief with: Goal, Done definition, Constraints, and Non-goals.
-	•	Separate facts, assumptions, and open questions before proposing implementation steps.
-	•	Work in thin vertical slices (one behavior/invariant at a time), not broad local rewrites.
-	•	For each slice, define one checkpoint command and expected result before editing code.
-	•	Prefer domain truth and boundaries over speed: keep money logic BigDecimal-based and keep domain modules framework-free.
-	•	After each slice, run the checkpoint and capture what changed, what passed, and what remains.
-	•	When making design choices, present 2-3 options with tradeoffs and ask for preference if impactful.
-	•	Record important decisions in GitHub milestones/issues or task notes so future work follows the same process.
-	•	End every task with a short retrospective: what was learned, what risk remains, and next best step.
+- Start from outcome, not files: first map the task to roadmap phase or milestone and restate the done criteria.
+- Before coding, write the mini brief with Goal, Done, Constraints, and Non-goals.
+- Separate facts, assumptions, and open questions before proposing implementation steps.
+- Work in thin vertical slices, one behavior or invariant at a time, not broad local rewrites.
+- For each slice, define one checkpoint command and expected result before editing code.
+- Prefer domain truth and boundaries over speed: keep money logic `BigDecimal`-based and keep domain modules framework-free.
+- After each slice, run the checkpoint and capture what changed, what passed, and what remains.
+- When making design choices, present 2-3 options with tradeoffs and ask for preference if the choice is impactful.
+- Record important decisions in GitHub milestones, issues, or task notes so future work follows the same process.
+- End every task with a short retrospective: what was learned, what risk remains, and the next best step.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🌿 Mindful Finance
 
+[![Built with Codex](https://img.shields.io/badge/Built%20with-Codex-0A66C2?logo=openai&logoColor=white)](https://openai.com/codex/)
+
 **Подход Calm Architect к финансовой свободе.**
 
 ## 🎯 Видение

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,47 @@
+This file adds backend-local rules on top of the root [`AGENTS.md`](../AGENTS.md).
+
+Scope
+- Applies to `backend/**`.
+- Keep the root mini brief, facts/assumptions/open questions, thin-slice planning, checkpoint-first workflow, and retrospective.
+
+Backend operating model
+- Prefer inside-out slices: domain -> application -> adapters (`postgres`) -> transport (`api`).
+- Before editing, state which module is the source of truth for the slice.
+- Keep each slice narrow: one invariant, one use case seam, one repository mapping, or one endpoint behavior at a time.
+- Pick one checkpoint command and expected result before editing:
+  - Domain or application slice: `mvn --batch-mode -f backend/pom.xml -pl domain,application test`
+  - Adapter or API slice: `mvn --batch-mode -f backend/pom.xml test`
+- Final backend checkpoint: `mvn --batch-mode -f backend/pom.xml test`
+
+Architecture boundaries
+- `backend/domain` and `backend/application` must stay framework-free.
+- Do not add Spring, servlet, JDBC, JPA, or persistence annotations and imports to `domain` or `application`.
+- Keep business rules and money logic out of controllers and infrastructure adapters.
+- Adapters translate between framework or storage details and application ports. Do not leak transport DTOs, SQL types, or framework objects into domain logic.
+
+Controllers and transport
+- Controllers must be thin: parse transport input, delegate to explicit use cases, map transport output, and handle HTTP concerns.
+- Do not hide business decisions in controllers, request mappers, or response assemblers.
+- If a controller is already large, prefer extracting one endpoint flow or one mapper seam per slice instead of expanding the controller further.
+
+Use case design
+- Keep use cases small, explicit, and named by intent.
+- One use case should make one main decision flow obvious.
+- If branching or policy logic grows, extract a domain policy, helper, or value object with explicit inputs and outputs instead of growing orchestration code.
+- Prefer constructor-injected dependencies and explicit return values over hidden mutable state.
+
+Money rules
+- Money is `BigDecimal` only. Never introduce `float` or `double` for monetary logic.
+- Prefer the domain `Money` value object at domain and application boundaries.
+- Raw `BigDecimal` is acceptable only at clear storage or transport edges, or inside `Money` itself.
+- Make scale, currency, and rounding explicit. Never rely on implicit floating conversion or silent rounding.
+- Tests for money logic must assert exact values, currency, and rounding behavior.
+
+Testing and review
+- Add or update tests as close as possible to the changed behavior:
+  - Domain tests for invariants and value objects.
+  - Application tests for orchestration and port interactions.
+  - Postgres tests for mapping and persistence behavior.
+  - API tests for request and response contracts.
+- In review, explicitly check naming, boundaries, testability, file size, and hidden state coupling.
+- Use [`../code_review.md`](../code_review.md) as the review checklist.

--- a/code_review.md
+++ b/code_review.md
@@ -1,0 +1,70 @@
+# Code Review Guide
+
+Use this document for review requests and self-review before finishing a slice.
+
+## Review operating model
+
+- Start by clarifying scope if needed with a mini brief:
+  - Goal
+  - Done
+  - Constraints
+  - Non-goals
+- Separate facts, assumptions, and open questions before judging the change.
+- Findings come first. Summaries are secondary.
+- Each finding should explain the problem, why it matters, and the likely impact on behavior, maintenance, or future changes.
+- Verify concerns with the smallest relevant command, test, or scenario when possible.
+
+## Core review checklist
+
+### Naming
+
+- Do names reflect domain intent and user-facing behavior rather than implementation accidents?
+- Are classes, functions, hooks, and variables specific enough to be searchable and understandable?
+- Are overloaded or ambiguous names hiding multiple responsibilities?
+
+### Boundaries
+
+- Does the change preserve the intended boundaries between domain, application, adapters, and transport?
+- Are framework details kept out of backend domain and application code?
+- Are frontend presentational concerns kept separate from API orchestration and stateful effects?
+- Are controllers, hooks, helpers, and repositories doing only the work that belongs to them?
+
+### Testability
+
+- Can the important logic be exercised without hidden framework setup, global state, or timing tricks?
+- Are the key decisions isolated enough to test at the right level?
+- Does the change make future tests easier rather than harder?
+
+### File size and cohesion
+
+- Is the file, class, or component growing into a hotspot with too many responsibilities?
+- If the file is already large, did the change reduce or increase the concentration of logic?
+- Could one seam be extracted now without turning the change into a rewrite?
+
+### Hidden state coupling
+
+- Is behavior spread across implicit state, effects, mutable fields, or ordering assumptions?
+- Are there dependencies between props, local state, repository calls, async statuses, or side effects that are not explicit in the API?
+- Does the change introduce state that can drift out of sync with the real source of truth?
+
+## Backend-specific checks
+
+- Money logic uses `BigDecimal` or the domain `Money` model only.
+- Domain and application stay framework-free.
+- Controllers stay thin.
+- Use cases are small, explicit, and named by intent.
+- Adapters translate infrastructure concerns without leaking them upward.
+
+## Frontend-specific checks
+
+- The change is incremental, not a big-bang rewrite.
+- Pure helpers, custom hooks, and presentational components are extracted only when their inputs and outputs are explicit.
+- Large refactors have a safety-net test first, or the absence of such a test is called out as risk.
+- Effects do not coordinate unrelated concerns without a clear reason.
+
+## Review output model
+
+- List findings first, ordered by severity.
+- Reference the exact file and line when possible.
+- After findings, note open questions, assumptions, or residual risks.
+- If there are no findings, say that explicitly and still mention any testing gaps or review limits.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,37 @@
+This file adds frontend-local rules on top of the root [`AGENTS.md`](../AGENTS.md).
+
+Scope
+- Applies to `frontend/**`.
+- Keep the root mini brief, facts/assumptions/open questions, thin-slice planning, checkpoint-first workflow, and retrospective.
+
+Frontend operating model
+- Work in thin vertical slices with visible behavior checkpoints. No big-bang rewrite.
+- Before editing, name the seam you are changing: pure helper, custom hook, presentational component, API boundary, or page-level orchestration.
+- Keep each slice focused on one behavior or one extraction seam at a time.
+- Pick one checkpoint command and expected result before editing:
+  - Fast local checkpoint: `npm --prefix frontend run lint`
+  - Final frontend checkpoint: `npm --prefix frontend run build`
+  - If tests exist or you add them, run the narrowest relevant test command too and state why it covers the slice.
+
+Refactor rules
+- Do not do a broad rewrite of a feature or page to "clean it up".
+- Prefer extracting one pure helper, one custom hook, or one presentational component at a time.
+- Before a large or risky refactor, add a safety-net test first. If no test harness exists yet, say so and make the smallest reasonable plan to introduce one before deeper surgery.
+- Avoid changing state shape, markup, API wiring, and styling in the same slice unless the task explicitly requires it.
+
+Structure guidance
+- Put pure calculations, formatting, and mapping into pure helpers.
+- Put effectful orchestration and state transitions into custom hooks with explicit inputs and outputs.
+- Put render-heavy branches into presentational components driven by props.
+- Keep transport and API concerns near feature boundaries, not hidden deep in presentational code.
+- Before extraction, make hidden state coupling explicit: identify the props, local state, effects, refs, async status, and derived values that the extraction depends on.
+
+Large-file guidance
+- If you touch a large hotspot such as `src/features/personal-finance/PersonalFinanceView.tsx`, default to one seam per slice.
+- Prefer shrinking the hotspot incrementally instead of moving many concerns at once.
+- Make behavior preservation explicit with a checkpoint after each extraction.
+
+Testing and review
+- Add tests before major refactors. For smaller extractions, preserve behavior and verify with lint, build, and a focused manual scenario.
+- In review, explicitly check naming, boundaries, testability, file size, and hidden state coupling.
+- Use [`../code_review.md`](../code_review.md) as the review checklist.


### PR DESCRIPTION
## What changed
- updated the root `AGENTS.md` to make the Codex operating model more explicit and actionable
- added `backend/AGENTS.md` with local backend rules around framework boundaries, thin controllers, explicit use cases, and `BigDecimal` money handling
- added `frontend/AGENTS.md` with local frontend rules for thin vertical slices, incremental extraction, and test-first guardrails for larger refactors
- added `code_review.md` as the review checklist and linked it from the AGENTS files
- added a Codex badge to the root README

## Why
The repository already had strong principles, but they were more descriptive than operational. This change makes the expected Codex workflow explicit at the root and in local areas of the codebase so future tasks and reviews stay aligned with the architecture guard and current CI shape.

## Developer impact
- every task should now start with `Goal / Done / Constraints / Non-goals`
- work should be split into thin vertical slices with one checkpoint command per slice
- backend and frontend work now pick up local guardrails automatically
- review requests now have a shared checklist for naming, boundaries, testability, file size, and hidden state coupling

## Validation
- `git diff --check --cached`
- docs-only change; no backend/frontend build or test commands were needed
