### PR TITLE
[codex] Extract top-level app shell navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import {
   type PersonalFinanceCardListItem,
   type PersonalFinanceTab,
 } from './features/personal-finance'
+import { AppShell, type ViewTab } from './features/app-shell'
 import { formatMoneyInput, normalizeMoneyInput } from './money-input'
 
 interface DashboardData {
@@ -49,7 +50,6 @@ interface AccountWithBalance extends AccountDto {
 }
 
 type LoadStatus = 'idle' | 'loading' | 'ready' | 'error'
-type ViewTab = 'dashboard' | 'accounts' | 'personal-finance'
 type TransactionDirectionFilter = 'ALL' | 'INFLOW' | 'OUTFLOW'
 type CreateAccountStatus = 'idle' | 'submitting' | 'error'
 type CreateTransactionStatus = 'idle' | 'submitting' | 'error'
@@ -491,8 +491,6 @@ function App() {
     })
   }, [transactions, directionFilter, memoFilter])
 
-  const localizedTitle = getViewTitle(activeView)
-  const localizedDescription = getViewDescription(activeView)
   const headerContextLabel =
     activeView === 'personal-finance'
       ? activePersonalFinanceTab === 'settings'
@@ -813,124 +811,89 @@ function App() {
   }
 
   return (
-    <main className="min-h-screen w-full px-4 py-8 sm:px-6 sm:py-14">
-      <section className="rounded-2xl border border-slate-200 bg-white/85 p-5 shadow-sm backdrop-blur lg:p-8">
-        <header className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
-              Mindful Finance
-            </p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-900">
-              {localizedTitle}
-            </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-600">
-              {localizedDescription}
-            </p>
-          </div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">
-            {headerContextLabel}
-          </p>
-        </header>
-
-        <nav className="mt-8 inline-flex rounded-xl border border-slate-200 bg-slate-50 p-1">
-          <TabButton
-            label="Обзор"
-            isActive={activeView === 'dashboard'}
-            onClick={() => setActiveView('dashboard')}
-          />
-          <TabButton
-            label="Инвестиции"
-            isActive={activeView === 'accounts'}
-            onClick={() => setActiveView('accounts')}
-          />
-          <TabButton
-            label="Личные финансы"
-            isActive={activeView === 'personal-finance'}
-            onClick={() => setActiveView('personal-finance')}
-          />
-        </nav>
-
-        <section className="mt-6">
-          {activeView === 'dashboard' ? (
-            <DashboardView
-              status={dashboardStatus}
-              dashboard={dashboard}
-              errorMessage={dashboardErrorMessage}
-              onRetry={() => {
-                setDashboardErrorMessage(null)
-                setDashboardReloadTick((tick) => tick + 1)
-              }}
-            />
-          ) : activeView === 'personal-finance' ? (
-            <PersonalFinanceView
-              status={personalFinanceStatus}
-              cards={personalFinanceCards}
-              activeSnapshots={activePersonalFinanceSnapshots}
-              settingsSnapshot={selectedPersonalFinanceSettingsSnapshot}
-              selectedCardId={selectedPersonalFinanceCardId}
-              activeTab={activePersonalFinanceTab}
-              year={selectedPersonalFinanceYear}
-              errorMessage={personalFinanceErrorMessage}
-              onSelectTab={setActivePersonalFinanceTab}
-              onSelectYear={setSelectedPersonalFinanceYear}
-              onSelectCard={setSelectedPersonalFinanceCardId}
-              onRetry={() => {
-                setPersonalFinanceErrorMessage(null)
-                setPersonalFinanceReloadTick((tick) => tick + 1)
-              }}
-              onCreateCard={handleCreatePersonalFinanceCard}
-              onSaveExpenseActual={handleSaveExpenseActual}
-              onCreateTransfer={handleCreatePersonalFinanceTransfer}
-              onSaveIncomeActual={handleSaveIncomeActual}
-              onSaveIncomePlan={handleSaveIncomePlan}
-              onRenameCard={handleRenamePersonalFinanceCard}
-              onSaveSettings={handleSavePersonalFinanceSettings}
-              onArchiveCard={handleArchivePersonalFinanceCard}
-              onRestoreCard={handleRestorePersonalFinanceCard}
-              onDeleteCard={handleDeletePersonalFinanceCard}
-            />
-          ) : (
-            <AccountsView
-              status={accountsStatus}
-              accounts={accounts}
-              selectedAccountId={selectedAccountId}
-              selectedAccount={selectedAccount}
-              transactionsStatus={transactionsStatus}
-              transactionsErrorMessage={transactionsErrorMessage}
-              filteredTransactions={filteredTransactions}
-              totalTransactionsCount={transactions.length}
-              directionFilter={directionFilter}
-              memoFilter={memoFilter}
-              onDirectionFilterChange={setDirectionFilter}
-              onMemoFilterChange={setMemoFilter}
-              onSelectAccount={handleAccountSelect}
-              createAccountStatus={createAccountStatus}
-              createAccountErrorMessage={createAccountErrorMessage}
-              onCreateAccount={handleCreateAccount}
-              onUpdateAccount={handleUpdateAccount}
-              onDeleteAccount={handleDeleteAccount}
-              createTransactionStatus={createTransactionStatus}
-              createTransactionErrorMessage={createTransactionErrorMessage}
-              onCreateTransaction={handleCreateTransaction}
-              onUpdateTransaction={handleUpdateTransaction}
-              onDeleteTransaction={handleDeleteTransaction}
-              csvImportStatus={csvImportStatus}
-              csvImportErrorMessage={csvImportErrorMessage}
-              csvImportResult={csvImportResult}
-              onImportTransactionsCsv={handleImportTransactionsCsv}
-              errorMessage={accountsErrorMessage}
-              onRetryAccounts={() => {
-                setAccountsErrorMessage(null)
-                setAccountsReloadTick((tick) => tick + 1)
-              }}
-              onRetryTransactions={() => {
-                setTransactionsReloadTick((tick) => tick + 1)
-              }}
-            />
-          )}
-        </section>
-      </section>
-    </main>
+    <AppShell
+      activeView={activeView}
+      headerContextLabel={headerContextLabel}
+      onSelectView={setActiveView}
+    >
+      {activeView === 'dashboard' ? (
+        <DashboardView
+          status={dashboardStatus}
+          dashboard={dashboard}
+          errorMessage={dashboardErrorMessage}
+          onRetry={() => {
+            setDashboardErrorMessage(null)
+            setDashboardReloadTick((tick) => tick + 1)
+          }}
+        />
+      ) : activeView === 'personal-finance' ? (
+        <PersonalFinanceView
+          status={personalFinanceStatus}
+          cards={personalFinanceCards}
+          activeSnapshots={activePersonalFinanceSnapshots}
+          settingsSnapshot={selectedPersonalFinanceSettingsSnapshot}
+          selectedCardId={selectedPersonalFinanceCardId}
+          activeTab={activePersonalFinanceTab}
+          year={selectedPersonalFinanceYear}
+          errorMessage={personalFinanceErrorMessage}
+          onSelectTab={setActivePersonalFinanceTab}
+          onSelectYear={setSelectedPersonalFinanceYear}
+          onSelectCard={setSelectedPersonalFinanceCardId}
+          onRetry={() => {
+            setPersonalFinanceErrorMessage(null)
+            setPersonalFinanceReloadTick((tick) => tick + 1)
+          }}
+          onCreateCard={handleCreatePersonalFinanceCard}
+          onSaveExpenseActual={handleSaveExpenseActual}
+          onCreateTransfer={handleCreatePersonalFinanceTransfer}
+          onSaveIncomeActual={handleSaveIncomeActual}
+          onSaveIncomePlan={handleSaveIncomePlan}
+          onRenameCard={handleRenamePersonalFinanceCard}
+          onSaveSettings={handleSavePersonalFinanceSettings}
+          onArchiveCard={handleArchivePersonalFinanceCard}
+          onRestoreCard={handleRestorePersonalFinanceCard}
+          onDeleteCard={handleDeletePersonalFinanceCard}
+        />
+      ) : (
+        <AccountsView
+          status={accountsStatus}
+          accounts={accounts}
+          selectedAccountId={selectedAccountId}
+          selectedAccount={selectedAccount}
+          transactionsStatus={transactionsStatus}
+          transactionsErrorMessage={transactionsErrorMessage}
+          filteredTransactions={filteredTransactions}
+          totalTransactionsCount={transactions.length}
+          directionFilter={directionFilter}
+          memoFilter={memoFilter}
+          onDirectionFilterChange={setDirectionFilter}
+          onMemoFilterChange={setMemoFilter}
+          onSelectAccount={handleAccountSelect}
+          createAccountStatus={createAccountStatus}
+          createAccountErrorMessage={createAccountErrorMessage}
+          onCreateAccount={handleCreateAccount}
+          onUpdateAccount={handleUpdateAccount}
+          onDeleteAccount={handleDeleteAccount}
+          createTransactionStatus={createTransactionStatus}
+          createTransactionErrorMessage={createTransactionErrorMessage}
+          onCreateTransaction={handleCreateTransaction}
+          onUpdateTransaction={handleUpdateTransaction}
+          onDeleteTransaction={handleDeleteTransaction}
+          csvImportStatus={csvImportStatus}
+          csvImportErrorMessage={csvImportErrorMessage}
+          csvImportResult={csvImportResult}
+          onImportTransactionsCsv={handleImportTransactionsCsv}
+          errorMessage={accountsErrorMessage}
+          onRetryAccounts={() => {
+            setAccountsErrorMessage(null)
+            setAccountsReloadTick((tick) => tick + 1)
+          }}
+          onRetryTransactions={() => {
+            setTransactionsReloadTick((tick) => tick + 1)
+          }}
+        />
+      )}
+    </AppShell>
   )
 }
 
@@ -2150,28 +2113,6 @@ function AccountsView({
   )
 }
 
-interface TabButtonProps {
-  label: string
-  isActive: boolean
-  onClick: () => void
-}
-
-function TabButton({ label, isActive, onClick }: TabButtonProps) {
-  const activeClasses = isActive
-    ? 'bg-white text-slate-900 shadow-sm'
-    : 'bg-transparent text-slate-500 hover:text-slate-800'
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${activeClasses}`}
-    >
-      {label}
-    </button>
-  )
-}
-
 interface MetricCardProps {
   title: string
   subtitle: string
@@ -2486,26 +2427,6 @@ function getAccountCurrencyOptions(): string[] {
       dynamicOptions.map((currencyCode) => currencyCode.toUpperCase()),
     ),
   ].sort((left, right) => left.localeCompare(right))
-}
-
-function getViewTitle(view: ViewTab): string {
-  if (view === 'accounts') {
-    return 'Инвестиции'
-  }
-  if (view === 'personal-finance') {
-    return 'Личные финансы'
-  }
-  return 'Обзор'
-}
-
-function getViewDescription(view: ViewTab): string {
-  if (view === 'accounts') {
-    return 'Инвестиционные счета и активы с балансами, деталями транзакций и простыми фильтрами.'
-  }
-  if (view === 'personal-finance') {
-    return 'Ручной yearly review по картам: факт расходов, лимиты, фактический доход и прогноз.'
-  }
-  return 'Спокойный срез капитала и метрик финансового спокойствия.'
 }
 
 function readNavigationFromUrl(): NavigationState {

--- a/frontend/src/features/app-shell/AppShell.tsx
+++ b/frontend/src/features/app-shell/AppShell.tsx
@@ -1,0 +1,108 @@
+import { type ReactNode } from 'react'
+
+export type ViewTab = 'dashboard' | 'accounts' | 'personal-finance'
+
+interface AppShellProps {
+  activeView: ViewTab
+  headerContextLabel: string
+  onSelectView: (view: ViewTab) => void
+  children: ReactNode
+}
+
+interface ViewCopy {
+  label: string
+  description: string
+}
+
+interface TabButtonProps {
+  label: string
+  isActive: boolean
+  onClick: () => void
+}
+
+const VIEW_COPY: Record<ViewTab, ViewCopy> = {
+  dashboard: {
+    label: 'Обзор',
+    description: 'Спокойный срез капитала и метрик финансового спокойствия.',
+  },
+  accounts: {
+    label: 'Инвестиции',
+    description:
+      'Инвестиционные счета и активы с балансами, деталями транзакций и простыми фильтрами.',
+  },
+  'personal-finance': {
+    label: 'Личные финансы',
+    description:
+      'Ручной yearly review по картам: факт расходов, лимиты, фактический доход и прогноз.',
+  },
+}
+
+const VIEW_ORDER: ViewTab[] = ['dashboard', 'accounts', 'personal-finance']
+
+export function AppShell({
+  activeView,
+  headerContextLabel,
+  onSelectView,
+  children,
+}: AppShellProps) {
+  const activeViewCopy = VIEW_COPY[activeView]
+
+  return (
+    <main className="min-h-screen w-full px-4 py-8 sm:px-6 sm:py-14">
+      <div className="space-y-6">
+        <nav
+          aria-label="Основные разделы"
+          className="rounded-2xl border border-slate-200 bg-white/85 p-2 shadow-sm backdrop-blur"
+        >
+          <div className="flex flex-wrap gap-2">
+            {VIEW_ORDER.map((view) => (
+              <TabButton
+                key={view}
+                label={VIEW_COPY[view].label}
+                isActive={activeView === view}
+                onClick={() => onSelectView(view)}
+              />
+            ))}
+          </div>
+        </nav>
+
+        <section className="rounded-2xl border border-slate-200 bg-white/85 p-5 shadow-sm backdrop-blur lg:p-8">
+          <header className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                Mindful Finance
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-900">
+                {activeViewCopy.label}
+              </h1>
+              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-600">
+                {activeViewCopy.description}
+              </p>
+            </div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">
+              {headerContextLabel}
+            </p>
+          </header>
+
+          <section className="mt-6">{children}</section>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function TabButton({ label, isActive, onClick }: TabButtonProps) {
+  const activeClasses = isActive
+    ? 'bg-white text-slate-900 shadow-sm'
+    : 'bg-transparent text-slate-500 hover:text-slate-800'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${activeClasses}`}
+    >
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/features/app-shell/index.ts
+++ b/frontend/src/features/app-shell/index.ts
@@ -1,0 +1,1 @@
+export { AppShell, type ViewTab } from './AppShell'


### PR DESCRIPTION
## What changed
- extracted the top-level page shell from `frontend/src/App.tsx` into `frontend/src/features/app-shell/AppShell.tsx`
- moved the `Обзор / Инвестиции / Личные финансы` navigation into a separate top menu above the main content card
- exported `ViewTab` from the new app-shell feature and removed the old inline shell helpers from `App.tsx`

## Why
`App.tsx` was carrying both orchestration state and page-level layout, which made the file harder to read and change safely. This change isolates the presentational shell while preserving the existing navigation and URL-sync behavior.

## Impact
- the top-level navigation is now visually placed above the content card
- `App.tsx` reads more like a container/orchestration layer
- no backend or API contracts changed

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
