### PR TITLE
[codex] Implement investment trade workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,8 +38,8 @@ Optimize for safe incremental delivery and engineer skill growth, not for maximu
 - Frontend fast: `npm --prefix frontend run lint`
 - Frontend final: `npm --prefix frontend run build`
 - End-to-end local runtime: `make dev`
-- API health: `curl http://localhost:8080/health`
-- Frontend URL: `http://localhost:5173`
+- API health: `curl http://localhost:${MINDFUL_FINANCE_API_PORT:-8080}/health`
+- Frontend URL: `http://localhost:${MINDFUL_FINANCE_FRONTEND_PORT:-5173}`
 - Stop local stack: `make down`
 
 ## Reviews

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,20 @@
             "preLaunchTask": "Mindful Finance: Start local Postgres",
             "env": {
                 "SPRING_PROFILES_ACTIVE": "postgres",
+                "SERVER_PORT": "${input:mindfulFinanceApiPort}",
+                "MINDFUL_FINANCE_API_PORT": "${input:mindfulFinanceApiPort}",
                 "MINDFUL_FINANCE_DB_URL": "jdbc:postgresql://localhost:55432/mindfulfinance",
                 "MINDFUL_FINANCE_DB_USERNAME": "mindfulfinance",
                 "MINDFUL_FINANCE_DB_PASSWORD": "mindfulfinance"
             }
+        }
+    ],
+    "inputs": [
+        {
+            "id": "mindfulFinanceApiPort",
+            "type": "promptString",
+            "description": "API port for local launch",
+            "default": "8080"
         }
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,17 @@ SPRING_PROFILES_ACTIVE ?= postgres
 MINDFUL_FINANCE_DB_URL ?= jdbc:postgresql://localhost:55432/mindfulfinance
 MINDFUL_FINANCE_DB_USERNAME ?= mindfulfinance
 MINDFUL_FINANCE_DB_PASSWORD ?= mindfulfinance
-BACKEND_ENV := SPRING_PROFILES_ACTIVE=$(SPRING_PROFILES_ACTIVE) MINDFUL_FINANCE_DB_URL=$(MINDFUL_FINANCE_DB_URL) MINDFUL_FINANCE_DB_USERNAME=$(MINDFUL_FINANCE_DB_USERNAME) MINDFUL_FINANCE_DB_PASSWORD=$(MINDFUL_FINANCE_DB_PASSWORD)
+MINDFUL_FINANCE_API_PORT ?= 8080
+MINDFUL_FINANCE_FRONTEND_PORT ?= 5173
+BACKEND_ENV := SPRING_PROFILES_ACTIVE=$(SPRING_PROFILES_ACTIVE) SERVER_PORT=$(MINDFUL_FINANCE_API_PORT) MINDFUL_FINANCE_DB_URL=$(MINDFUL_FINANCE_DB_URL) MINDFUL_FINANCE_DB_USERNAME=$(MINDFUL_FINANCE_DB_USERNAME) MINDFUL_FINANCE_DB_PASSWORD=$(MINDFUL_FINANCE_DB_PASSWORD)
+FRONTEND_ENV := MINDFUL_FINANCE_API_PORT=$(MINDFUL_FINANCE_API_PORT) MINDFUL_FINANCE_FRONTEND_PORT=$(MINDFUL_FINANCE_FRONTEND_PORT)
 BACKEND_PREPARE_CMD := mvn -f $(BACKEND_POM) -pl api -am -Dmaven.test.skip=true install
 BACKEND_DEV_CMD := $(BACKEND_ENV) mvn -f $(BACKEND_POM) -pl api -am -rf :api spring-boot:run
 BACKEND_BUILD_CMD := mvn -f $(BACKEND_POM) -Dmaven.test.skip=true package
-FRONTEND_DEV_CMD := npm --prefix $(FRONTEND_DIR) run dev
+FRONTEND_DEV_CMD := $(FRONTEND_ENV) npm --prefix $(FRONTEND_DIR) run dev
 FRONTEND_BUILD_CMD := npm --prefix $(FRONTEND_DIR) run build
 
-.PHONY: dev build down frontend-deps db-up backend-dev
+.PHONY: dev build down frontend-deps db-up backend-dev backend-prepare
 
 $(FRONTEND_STAMP): $(FRONTEND_DIR)/package.json $(FRONTEND_DIR)/package-lock.json
 	@echo "Installing frontend dependencies..."
@@ -26,6 +29,10 @@ $(FRONTEND_STAMP): $(FRONTEND_DIR)/package.json $(FRONTEND_DIR)/package-lock.jso
 	@touch $(FRONTEND_STAMP)
 
 frontend-deps: $(FRONTEND_STAMP)
+
+backend-prepare:
+	@echo "Preparing backend modules..."
+	@$(BACKEND_PREPARE_CMD)
 
 build: $(FRONTEND_STAMP)
 	@echo "Building backend..."
@@ -52,14 +59,11 @@ db-up:
 	done; \
 	echo "PostgreSQL is healthy."
 
-backend-dev:
-	@echo "Preparing backend modules..."
-	@$(BACKEND_PREPARE_CMD)
-	@$(MAKE) db-up
-	@echo "Starting backend on http://localhost:8080 ..."
+backend-dev: backend-prepare db-up
+	@echo "Starting backend on http://localhost:$(MINDFUL_FINANCE_API_PORT) ..."
 	@$(BACKEND_DEV_CMD)
 
-dev: $(FRONTEND_STAMP)
+dev: $(FRONTEND_STAMP) backend-prepare db-up
 	@set -eu; \
 	backend_pid=""; \
 	frontend_pid=""; \
@@ -80,13 +84,10 @@ dev: $(FRONTEND_STAMP)
 		exit "$$status"; \
 	}; \
 	trap 'cleanup 130' INT TERM; \
-	echo "Preparing backend modules..."; \
-	$(BACKEND_PREPARE_CMD); \
-	$(MAKE) db-up; \
-	echo "Starting backend on http://localhost:8080 ..."; \
+	echo "Starting backend on http://localhost:$(MINDFUL_FINANCE_API_PORT) ..."; \
 	$(BACKEND_DEV_CMD) & \
 	backend_pid=$$!; \
-	echo "Starting frontend on http://localhost:5173 ..."; \
+	echo "Starting frontend on http://localhost:$(MINDFUL_FINANCE_FRONTEND_PORT) ..."; \
 	$(FRONTEND_DEV_CMD) & \
 	frontend_pid=$$!; \
 	echo "Dev stack is running. Press Ctrl+C to stop app processes; PostgreSQL stays up."; \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@
 make dev
 ```
 
+Безопасно посмотреть orchestration-план без запуска процессов можно через:
+```bash
+make -n dev
+```
+
 Что делает `make dev`:
 - подготавливает backend-модули для запуска API без отдельного ручного `mvn install`;
 - поднимает PostgreSQL из `backend/docker-compose.yml`;
@@ -47,13 +52,13 @@ make dev
 - при первом запуске или изменении `frontend/package-lock.json` автоматически выполняет `npm ci`.
 
 После старта:
-- API доступен на `http://localhost:8080`;
-- health-check: `curl http://localhost:8080/health`;
+- API доступен на `http://localhost:${MINDFUL_FINANCE_API_PORT:-8080}`;
+- health-check: `curl http://localhost:${MINDFUL_FINANCE_API_PORT:-8080}/health`;
 - ожидаемый ответ:
 ```json
 {"status":"ok"}
 ```
-- frontend доступен на `http://localhost:5173`.
+- frontend доступен на `http://localhost:${MINDFUL_FINANCE_FRONTEND_PORT:-5173}`.
 
 Остановка приложения:
 - `Ctrl+C` завершает backend и frontend;
@@ -78,18 +83,28 @@ make build
 
 Локальная база данных доступна на `localhost:55432`, чтобы не конфликтовать с PostgreSQL на `5432`.
 
-По умолчанию frontend использует `VITE_API_BASE_URL=/api`, а Vite-прокси перенаправляет запросы на `http://localhost:8080`.
+По умолчанию frontend использует `VITE_API_BASE_URL=/api`, а Vite-прокси перенаправляет запросы на `http://localhost:${MINDFUL_FINANCE_API_PORT:-8080}`.
 
 При необходимости параметры подключения к БД можно переопределить переменными окружения:
 - `MINDFUL_FINANCE_DB_URL`
 - `MINDFUL_FINANCE_DB_USERNAME`
 - `MINDFUL_FINANCE_DB_PASSWORD`
 
+Порты локального runtime тоже можно переопределить переменными окружения:
+- `MINDFUL_FINANCE_API_PORT` для Spring Boot API;
+- `MINDFUL_FINANCE_FRONTEND_PORT` для Vite dev server;
+- `VITE_DEV_PROXY_TARGET`, если frontend должен проксировать API не на локальный backend-порт, а на другой target.
+
 ## ☕ Backend-only запуск для разработки
 
 Если нужен только API без frontend, используй отдельный backend runtime из корня репозитория:
 ```bash
 make backend-dev
+```
+
+Безопасный dry-run для этого пути:
+```bash
+make -n backend-dev
 ```
 
 Этот режим:
@@ -99,6 +114,7 @@ make backend-dev
 - использует те же `MINDFUL_FINANCE_DB_*`, что и `make dev`.
 
 Для VS Code в репозитории сохранён launch config `Mindful Finance API (postgres)` и pre-launch task, который поднимает локальный PostgreSQL перед стартом приложения.
+При запуске VS Code попросит указать API port; если просто нажать Enter, будет использован `8080`.
 
 Ручной локальный backend-запуск без профиля `postgres` считается вспомогательным in-memory режимом, а не основным dev-runtime.
 

--- a/backend/api/src/main/java/com/mindfulfinance/api/AccountsController.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/AccountsController.java
@@ -12,6 +12,8 @@ import com.mindfulfinance.application.usecases.ComputeNetWorthByCurrency;
 import com.mindfulfinance.application.usecases.DeleteAccount;
 import com.mindfulfinance.application.usecases.DeleteTransaction;
 import com.mindfulfinance.application.usecases.ImportTransactions;
+import com.mindfulfinance.application.usecases.ListInvestmentTransactions;
+import com.mindfulfinance.application.usecases.SearchAccountInstruments;
 import com.mindfulfinance.application.usecases.UpdateAccount;
 import com.mindfulfinance.application.usecases.UpdateTransaction;
 import com.mindfulfinance.domain.account.Account;
@@ -21,6 +23,7 @@ import com.mindfulfinance.domain.money.Money;
 import com.mindfulfinance.domain.transaction.Transaction;
 import com.mindfulfinance.domain.transaction.TransactionDirection;
 import com.mindfulfinance.domain.transaction.TransactionId;
+import com.mindfulfinance.domain.transaction.TransactionTrade;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -59,6 +62,8 @@ public class AccountsController {
   private final DeleteTransaction deleteTransactionUseCase;
   private final UpdateAccount updateAccount;
   private final UpdateTransaction updateTransaction;
+  private final SearchAccountInstruments searchAccountInstruments;
+  private final ListInvestmentTransactions listInvestmentTransactions;
 
   public AccountsController(
       AccountRepository accountRepository,
@@ -72,7 +77,9 @@ public class AccountsController {
       ImportTransactions importTransactions,
       DeleteTransaction deleteTransactionUseCase,
       UpdateAccount updateAccount,
-      UpdateTransaction updateTransaction) {
+      UpdateTransaction updateTransaction,
+      SearchAccountInstruments searchAccountInstruments,
+      ListInvestmentTransactions listInvestmentTransactions) {
     this.accountRepository = accountRepository;
     this.personalFinanceCardRepository = personalFinanceCardRepository;
     this.transactionRepository = transactionRepository;
@@ -85,6 +92,8 @@ public class AccountsController {
     this.deleteTransactionUseCase = deleteTransactionUseCase;
     this.updateAccount = updateAccount;
     this.updateTransaction = updateTransaction;
+    this.searchAccountInstruments = searchAccountInstruments;
+    this.listInvestmentTransactions = listInvestmentTransactions;
   }
 
   // Milestone 3: create account endpoint for the HTTP adapter v0.
@@ -158,6 +167,8 @@ public class AccountsController {
       @PathVariable("accountId") String accountId, @RequestBody CreateTransactionRequest req) {
     AccountId parsedAccountId = parseAccountId(accountId);
     Account account = requireInvestmentAccount(parsedAccountId);
+    TransactionTrade trade = toTrade(req, account.currency());
+    Money amount = resolveTransactionAmount(req.direction(), account.currency(), req.amount(), trade);
 
     Transaction tx =
         new Transaction(
@@ -165,9 +176,10 @@ public class AccountsController {
             parsedAccountId,
             req.occurredOn(),
             req.direction(),
-            new Money(req.amount(), account.currency()),
+            amount,
             req.memo(),
-            Instant.now());
+            Instant.now(),
+            trade);
 
     transactionRepository.save(tx);
     return ResponseEntity.status(HttpStatus.CREATED)
@@ -177,18 +189,31 @@ public class AccountsController {
   @GetMapping("/accounts/{accountId}/transactions")
   public List<TransactionDto> getTransactions(@PathVariable("accountId") String accountId) {
     AccountId parsedAccountId = parseAccountId(accountId);
-    requireInvestmentAccount(parsedAccountId);
+    Account account = requireInvestmentAccount(parsedAccountId);
 
     return transactionRepository.findByAccountId(parsedAccountId).stream()
-        .map(
-            tx ->
-                new TransactionDto(
-                    tx.id().value().toString(),
-                    tx.occurredOn(),
-                    tx.direction().name(),
-                    tx.amount().amount().toPlainString(),
-                    tx.amount().currency().getCurrencyCode(),
-                    tx.memo()))
+        .map(tx -> toTransactionDto(account, tx))
+        .toList();
+  }
+
+  @GetMapping("/accounts/{accountId}/instruments")
+  public List<InstrumentOptionDto> getAccountInstruments(
+      @PathVariable("accountId") String accountId,
+      @RequestParam(value = "q", required = false) String query) {
+    AccountId parsedAccountId = parseAccountId(accountId);
+
+    return searchAccountInstruments
+        .search(new SearchAccountInstruments.Command(parsedAccountId, query))
+        .orElseThrow(() -> new AccountNotFoundException("Account not found"))
+        .stream()
+        .map(AccountsController::toInstrumentOptionDto)
+        .toList();
+  }
+
+  @GetMapping("/investment-transactions")
+  public List<TransactionDto> getInvestmentTransactions() {
+    return listInvestmentTransactions.list().stream()
+        .map(row -> toTransactionDto(row.account(), row.transaction()))
         .toList();
   }
 
@@ -211,7 +236,11 @@ public class AccountsController {
                     req.occurredOn(),
                     req.direction(),
                     req.amount(),
-                    req.memo()))
+                    req.memo(),
+                    req.instrumentSymbol(),
+                    req.quantity(),
+                    req.unitPrice(),
+                    req.feeAmount()))
             .isPresent();
 
     if (!updated) {
@@ -359,6 +388,55 @@ public class AccountsController {
     return new MoneyDto(money.amount().toPlainString(), money.currency().getCurrencyCode());
   }
 
+  private static TransactionTrade toTrade(
+      CreateTransactionRequest request, Currency currency) {
+    return Transaction.trade(
+        request.instrumentSymbol(),
+        request.quantity(),
+        toMoney(request.unitPrice(), currency),
+        toMoney(request.feeAmount(), currency));
+  }
+
+  private static Money resolveTransactionAmount(
+      TransactionDirection direction, Currency currency, BigDecimal amount, TransactionTrade trade) {
+    if (trade != null) {
+      return trade.cashAmount(direction);
+    }
+    if (amount == null) {
+      throw new IllegalArgumentException("amount must not be null when trade details are absent");
+    }
+    return new Money(amount, currency);
+  }
+
+  private static Money toMoney(BigDecimal amount, Currency currency) {
+    if (amount == null || currency == null) {
+      return null;
+    }
+    return new Money(amount, currency);
+  }
+
+  private static TransactionDto toTransactionDto(Account account, Transaction transaction) {
+    return new TransactionDto(
+        transaction.id().value().toString(),
+        account.id().value().toString(),
+        account.name(),
+        transaction.occurredOn(),
+        transaction.direction().name(),
+        transaction.amount().amount().toPlainString(),
+        transaction.amount().currency().getCurrencyCode(),
+        transaction.memo(),
+        transaction.trade() == null ? null : transaction.trade().instrumentSymbol(),
+        transaction.trade() == null ? null : transaction.trade().quantity().toPlainString(),
+        transaction.trade() == null ? null : transaction.trade().unitPrice().amount().toPlainString(),
+        transaction.trade() == null ? null : transaction.trade().feeAmount().amount().toPlainString());
+  }
+
+  private static InstrumentOptionDto toInstrumentOptionDto(
+      com.mindfulfinance.application.ports.InstrumentCatalog.InstrumentOption option) {
+    return new InstrumentOptionDto(
+        option.symbol(), option.shortName(), option.name(), option.isin(), option.kind().name());
+  }
+
   public record CreateAccountResponse(String accountId) {}
 
   public record UpdateAccountRequest(String name, String type) {}
@@ -366,20 +444,43 @@ public class AccountsController {
   public record AccountDto(String id, String name, String currency, String type, String status) {}
 
   public record CreateTransactionRequest(
-      LocalDate occurredOn, TransactionDirection direction, BigDecimal amount, String memo) {}
+      LocalDate occurredOn,
+      TransactionDirection direction,
+      BigDecimal amount,
+      String memo,
+      String instrumentSymbol,
+      BigDecimal quantity,
+      BigDecimal unitPrice,
+      BigDecimal feeAmount) {}
 
   public record CreateTransactionResponse(String transactionId) {}
 
   public record UpdateTransactionRequest(
-      LocalDate occurredOn, TransactionDirection direction, BigDecimal amount, String memo) {}
+      LocalDate occurredOn,
+      TransactionDirection direction,
+      BigDecimal amount,
+      String memo,
+      String instrumentSymbol,
+      BigDecimal quantity,
+      BigDecimal unitPrice,
+      BigDecimal feeAmount) {}
 
   public record TransactionDto(
       String id,
+      String accountId,
+      String accountName,
       LocalDate occurredOn,
       String direction,
       String amount,
       String currency,
-      String memo) {}
+      String memo,
+      String instrumentSymbol,
+      String quantity,
+      String unitPrice,
+      String feeAmount) {}
+
+  public record InstrumentOptionDto(
+      String symbol, String shortName, String name, String isin, String kind) {}
 
   public record MoneyDto(String amount, String currency) {}
 

--- a/backend/api/src/main/java/com/mindfulfinance/api/ApiExceptionHandler.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/ApiExceptionHandler.java
@@ -42,6 +42,13 @@ public class ApiExceptionHandler {
         .body(new ApiError("BAD_REQUEST", ex.getMessage()));
   }
 
+  @ExceptionHandler(InstrumentCatalogUnavailableException.class)
+  public ResponseEntity<ApiError> handleServiceUnavailable(
+      InstrumentCatalogUnavailableException ex) {
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body(new ApiError("SERVICE_UNAVAILABLE", ex.getMessage()));
+  }
+
   @ExceptionHandler({IllegalStateException.class, DuplicateKeyException.class})
   public ResponseEntity<ApiError> handleConflict(RuntimeException ex) {
     return ResponseEntity.status(HttpStatus.CONFLICT)

--- a/backend/api/src/main/java/com/mindfulfinance/api/InstrumentCatalogUnavailableException.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/InstrumentCatalogUnavailableException.java
@@ -1,0 +1,7 @@
+package com.mindfulfinance.api;
+
+public final class InstrumentCatalogUnavailableException extends RuntimeException {
+  public InstrumentCatalogUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/backend/api/src/main/java/com/mindfulfinance/api/MoexInstrumentCatalog.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/MoexInstrumentCatalog.java
@@ -1,0 +1,202 @@
+package com.mindfulfinance.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mindfulfinance.application.ports.InstrumentCatalog;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+public final class MoexInstrumentCatalog implements InstrumentCatalog {
+  private static final String UNAVAILABLE_MESSAGE =
+      "Не удалось загрузить инструменты с Московской биржи. Попробуйте позже.";
+
+  private final RestClient restClient;
+  private final Clock clock;
+  private final Duration ttl;
+  private final Map<CacheKey, CacheEntry> cache = new ConcurrentHashMap<>();
+
+  public MoexInstrumentCatalog(RestClient restClient) {
+    this(restClient, Clock.systemUTC(), Duration.ofMinutes(15));
+  }
+
+  MoexInstrumentCatalog(RestClient restClient, Clock clock, Duration ttl) {
+    this.restClient = Objects.requireNonNull(restClient, "restClient");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.ttl = Objects.requireNonNull(ttl, "ttl");
+  }
+
+  @Override
+  public List<InstrumentOption> search(Query query) {
+    Objects.requireNonNull(query, "query");
+
+    String normalizedText = normalizeQuery(query.text());
+    CacheKey cacheKey = new CacheKey(query.scope(), normalizedText);
+    Instant now = clock.instant();
+    CacheEntry cached = cache.get(cacheKey);
+    if (cached != null && cached.expiresAt().isAfter(now)) {
+      return cached.results();
+    }
+
+    List<InstrumentOption> freshResults = fetchFromMoex(query.scope(), normalizedText);
+    cache.put(cacheKey, new CacheEntry(List.copyOf(freshResults), now.plus(ttl)));
+    return freshResults;
+  }
+
+  private List<InstrumentOption> fetchFromMoex(Scope scope, String text) {
+    try {
+      JsonNode responseBody =
+          restClient
+              .get()
+              .uri(
+                  uriBuilder ->
+                      uriBuilder
+                          .path("/securities.json")
+                          .queryParam("iss.meta", "off")
+                          .queryParam("lang", "en")
+                          .queryParam("limit", "50")
+                          .queryParam("q", text)
+                          .build())
+              .retrieve()
+              .body(JsonNode.class);
+
+      return extractOptions(responseBody, scope);
+    } catch (RestClientException | IllegalArgumentException ex) {
+      throw new InstrumentCatalogUnavailableException(UNAVAILABLE_MESSAGE, ex);
+    }
+  }
+
+  private static List<InstrumentOption> extractOptions(JsonNode responseBody, Scope scope) {
+    JsonNode securitiesNode = responseBody == null ? null : responseBody.path("securities");
+    JsonNode columnsNode = securitiesNode == null ? null : securitiesNode.path("columns");
+    JsonNode dataNode = securitiesNode == null ? null : securitiesNode.path("data");
+    if (columnsNode == null || !columnsNode.isArray() || dataNode == null || !dataNode.isArray()) {
+      throw new IllegalArgumentException("Unexpected MOEX ISS response");
+    }
+
+    Map<String, Integer> indexes = indexColumns(columnsNode);
+    LinkedHashMap<String, InstrumentOption> deduplicated = new LinkedHashMap<>();
+
+    for (JsonNode rowNode : dataNode) {
+      if (!rowNode.isArray()) {
+        continue;
+      }
+
+      if (!"1".equals(readText(rowNode, indexes, "is_traded"))) {
+        continue;
+      }
+
+      if ("INAV".equalsIgnoreCase(readText(rowNode, indexes, "primary_boardid"))) {
+        continue;
+      }
+
+      Kind kind = mapKind(readText(rowNode, indexes, "group"));
+      if (kind == null || !isAllowed(kind, scope)) {
+        continue;
+      }
+
+      String symbol = readText(rowNode, indexes, "secid");
+      if (symbol == null || symbol.isBlank() || deduplicated.containsKey(symbol)) {
+        continue;
+      }
+
+      deduplicated.put(
+          symbol,
+          new InstrumentOption(
+              symbol,
+              readNullableText(rowNode, indexes, "shortname"),
+              readNullableText(rowNode, indexes, "name"),
+              readNullableText(rowNode, indexes, "isin"),
+              kind));
+
+      if (deduplicated.size() == 20) {
+        break;
+      }
+    }
+
+    return new ArrayList<>(deduplicated.values());
+  }
+
+  private static Map<String, Integer> indexColumns(JsonNode columnsNode) {
+    Map<String, Integer> indexes = new LinkedHashMap<>();
+    for (int index = 0; index < columnsNode.size(); index += 1) {
+      indexes.put(columnsNode.get(index).asText(), index);
+    }
+
+    List<String> requiredColumns =
+        List.of("secid", "shortname", "name", "isin", "is_traded", "group", "primary_boardid");
+    for (String requiredColumn : requiredColumns) {
+      if (!indexes.containsKey(requiredColumn)) {
+        throw new IllegalArgumentException("Missing MOEX ISS column: " + requiredColumn);
+      }
+    }
+
+    return indexes;
+  }
+
+  private static boolean isAllowed(Kind kind, Scope scope) {
+    return switch (scope) {
+      case SHARES_AND_FUNDS -> kind == Kind.SHARE || kind == Kind.FUND;
+      case BONDS -> kind == Kind.BOND;
+    };
+  }
+
+  private static Kind mapKind(String group) {
+    if (group == null) {
+      return null;
+    }
+
+    return switch (group) {
+      case "stock_shares" -> Kind.SHARE;
+      case "stock_ppif" -> Kind.FUND;
+      case "stock_bonds" -> Kind.BOND;
+      default -> null;
+    };
+  }
+
+  private static String normalizeQuery(String text) {
+    return text == null ? "" : text.trim();
+  }
+
+  private static String readText(JsonNode rowNode, Map<String, Integer> indexes, String columnName) {
+    Integer index = indexes.get(columnName);
+    if (index == null || index >= rowNode.size()) {
+      return null;
+    }
+
+    JsonNode valueNode = rowNode.get(index);
+    if (valueNode == null || valueNode.isNull()) {
+      return null;
+    }
+
+    return valueNode.asText();
+  }
+
+  private static String readNullableText(
+      JsonNode rowNode, Map<String, Integer> indexes, String columnName) {
+    String value = readText(rowNode, indexes, columnName);
+    if (value == null) {
+      return null;
+    }
+
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private record CacheKey(Scope scope, String text) {
+    private CacheKey {
+      Objects.requireNonNull(scope, "scope");
+      text = text == null ? "" : text.toLowerCase(Locale.ROOT);
+    }
+  }
+
+  private record CacheEntry(List<InstrumentOption> results, Instant expiresAt) {}
+}

--- a/backend/api/src/main/java/com/mindfulfinance/api/config/ApiWiringConfig.java
+++ b/backend/api/src/main/java/com/mindfulfinance/api/config/ApiWiringConfig.java
@@ -8,7 +8,9 @@ import com.mindfulfinance.api.InMemoryMonthlyExpenseLimitRepository;
 import com.mindfulfinance.api.InMemoryMonthlyIncomeActualRepository;
 import com.mindfulfinance.api.InMemoryPersonalFinanceCardRepository;
 import com.mindfulfinance.api.InMemoryTransactionRepository;
+import com.mindfulfinance.api.MoexInstrumentCatalog;
 import com.mindfulfinance.application.ports.AccountRepository;
+import com.mindfulfinance.application.ports.InstrumentCatalog;
 import com.mindfulfinance.application.ports.IncomeForecastRepository;
 import com.mindfulfinance.application.ports.IncomePlanRepository;
 import com.mindfulfinance.application.ports.MonthlyExpenseActualRepository;
@@ -28,8 +30,10 @@ import com.mindfulfinance.application.usecases.DeleteTransaction;
 import com.mindfulfinance.application.usecases.GetCardPersonalFinanceSnapshot;
 import com.mindfulfinance.application.usecases.ImportTransactions;
 import com.mindfulfinance.application.usecases.ListPersonalFinanceCards;
+import com.mindfulfinance.application.usecases.ListInvestmentTransactions;
 import com.mindfulfinance.application.usecases.RenamePersonalFinanceCard;
 import com.mindfulfinance.application.usecases.RestorePersonalFinanceCard;
+import com.mindfulfinance.application.usecases.SearchAccountInstruments;
 import com.mindfulfinance.application.usecases.SaveIncomeForecast;
 import com.mindfulfinance.application.usecases.SaveIncomePlan;
 import com.mindfulfinance.application.usecases.SaveMonthlyExpenseActual;
@@ -53,8 +57,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class ApiWiringConfig {
@@ -217,6 +223,38 @@ public class ApiWiringConfig {
   @Bean
   public UpdateTransaction updateTransaction(TransactionRepository transactionRepository) {
     return new UpdateTransaction(transactionRepository);
+  }
+
+  @Bean
+  public RestClient moexRestClient(
+      @Value("${mindful-finance.moex.base-url:https://iss.moex.com/iss}") String baseUrl) {
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(3000);
+    requestFactory.setReadTimeout(3000);
+    return RestClient.builder().baseUrl(baseUrl).requestFactory(requestFactory).build();
+  }
+
+  @Bean
+  public InstrumentCatalog instrumentCatalog(RestClient moexRestClient) {
+    return new MoexInstrumentCatalog(moexRestClient);
+  }
+
+  @Bean
+  public SearchAccountInstruments searchAccountInstruments(
+      AccountRepository accountRepository,
+      PersonalFinanceCardRepository personalFinanceCardRepository,
+      InstrumentCatalog instrumentCatalog) {
+    return new SearchAccountInstruments(
+        accountRepository, personalFinanceCardRepository, instrumentCatalog);
+  }
+
+  @Bean
+  public ListInvestmentTransactions listInvestmentTransactions(
+      AccountRepository accountRepository,
+      PersonalFinanceCardRepository personalFinanceCardRepository,
+      TransactionRepository transactionRepository) {
+    return new ListInvestmentTransactions(
+        accountRepository, personalFinanceCardRepository, transactionRepository);
   }
 
   @Bean

--- a/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerPostgresIntegrationTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerPostgresIntegrationTest.java
@@ -2,6 +2,8 @@ package com.mindfulfinance.api;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -11,12 +13,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
+import com.mindfulfinance.application.ports.InstrumentCatalog;
+import com.mindfulfinance.application.usecases.CreatePersonalFinanceCard;
+import com.mindfulfinance.application.usecases.SavePersonalFinanceSettings;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCard;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
@@ -46,6 +53,9 @@ public class AccountsControllerPostgresIntegrationTest {
   @Autowired MockMvc mockMvc;
 
   @Autowired JdbcTemplate jdbcTemplate;
+  @Autowired CreatePersonalFinanceCard createPersonalFinanceCard;
+  @Autowired SavePersonalFinanceSettings savePersonalFinanceSettings;
+  @MockBean InstrumentCatalog instrumentCatalog;
 
   @BeforeEach
   void cleanDatabase() {
@@ -91,6 +101,8 @@ public class AccountsControllerPostgresIntegrationTest {
     mockMvc
         .perform(get("/accounts/{accountId}/transactions", accountId))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].accountId").value(accountId))
+        .andExpect(jsonPath("$[0].accountName").value("Cash"))
         .andExpect(jsonPath("$[0].direction").value("INFLOW"))
         .andExpect(jsonPath("$[0].amount").value("100.00"));
 
@@ -99,6 +111,186 @@ public class AccountsControllerPostgresIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.amount").value("100.00"))
         .andExpect(jsonPath("$.currency").value("USD"));
+  }
+
+  @Test
+  public void trade_transaction_endpoints_persist_trade_fields_with_postgres_profile()
+      throws Exception {
+    MvcResult accountResult =
+        mockMvc
+            .perform(
+                post("/accounts")
+                    .contentType("application/json")
+                    .content("{\"name\":\"Brokerage\",\"currency\":\"USD\",\"type\":\"BROKERAGE\"}"))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    String accountId =
+        JsonPath.read(accountResult.getResponse().getContentAsString(), "$.accountId");
+
+    mockMvc
+        .perform(
+            post("/accounts/{accountId}/transactions", accountId)
+                .contentType("application/json")
+                .content(
+                    """
+                    {
+                      "occurredOn":"2026-03-02",
+                      "direction":"OUTFLOW",
+                      "memo":"Buy AAPL",
+                      "instrumentSymbol":"aapl",
+                      "quantity":"2",
+                      "unitPrice":"100.00",
+                      "feeAmount":"1.50"
+                    }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.transactionId").exists());
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/transactions", accountId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].accountId").value(accountId))
+        .andExpect(jsonPath("$[0].accountName").value("Brokerage"))
+        .andExpect(jsonPath("$[0].amount").value("201.50"))
+        .andExpect(jsonPath("$[0].instrumentSymbol").value("AAPL"))
+        .andExpect(jsonPath("$[0].quantity").value("2"))
+        .andExpect(jsonPath("$[0].unitPrice").value("100.00"))
+        .andExpect(jsonPath("$[0].feeAmount").value("1.50"));
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/balance", accountId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.amount").value("-201.50"))
+        .andExpect(jsonPath("$.currency").value("USD"));
+  }
+
+  @Test
+  public void investment_transactions_endpoint_returns_global_sorted_rows_with_postgres_profile()
+      throws Exception {
+    String alphaAccountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType("application/json")
+                        .content(
+                            "{\"name\":\"Alpha Brokerage\",\"currency\":\"USD\",\"type\":\"BROKERAGE\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+    String betaAccountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType("application/json")
+                        .content(
+                            "{\"name\":\"Beta Cash\",\"currency\":\"EUR\",\"type\":\"CASH\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+
+    String alphaSameDayId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts/{accountId}/transactions", alphaAccountId)
+                        .contentType("application/json")
+                        .content(
+                            "{\"occurredOn\":\"2026-04-15\",\"direction\":\"OUTFLOW\",\"amount\":\"10.00\",\"memo\":\"Alpha same day\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.transactionId");
+    String olderAlphaId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts/{accountId}/transactions", alphaAccountId)
+                        .contentType("application/json")
+                        .content(
+                            "{\"occurredOn\":\"2026-04-10\",\"direction\":\"INFLOW\",\"amount\":\"50.00\",\"memo\":\"Alpha older\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.transactionId");
+    String betaSameDayLaterCreatedId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts/{accountId}/transactions", betaAccountId)
+                        .contentType("application/json")
+                        .content(
+                            "{\"occurredOn\":\"2026-04-15\",\"direction\":\"INFLOW\",\"amount\":\"200.00\",\"memo\":\"Beta same day\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.transactionId");
+
+    PersonalFinanceCard card =
+        createPersonalFinanceCard.create(new CreatePersonalFinanceCard.Command("Основная карта"));
+    savePersonalFinanceSettings.save(
+        new SavePersonalFinanceSettings.Command(
+            card.id(),
+            new java.math.BigDecimal("1000.00"),
+            java.util.Map.of(),
+            new java.math.BigDecimal("0.00"),
+            new java.math.BigDecimal("0.00")));
+
+    mockMvc
+        .perform(get("/investment-transactions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$[0].id").value(betaSameDayLaterCreatedId))
+        .andExpect(jsonPath("$[0].accountId").value(betaAccountId))
+        .andExpect(jsonPath("$[0].accountName").value("Beta Cash"))
+        .andExpect(jsonPath("$[1].id").value(alphaSameDayId))
+        .andExpect(jsonPath("$[1].accountId").value(alphaAccountId))
+        .andExpect(jsonPath("$[1].accountName").value("Alpha Brokerage"))
+        .andExpect(jsonPath("$[2].id").value(olderAlphaId))
+        .andExpect(jsonPath("$[2].accountId").value(alphaAccountId))
+        .andExpect(jsonPath("$[2].accountName").value("Alpha Brokerage"));
+  }
+
+  @Test
+  public void account_instruments_endpoint_returns_rows_with_postgres_profile() throws Exception {
+    String accountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType("application/json")
+                        .content(
+                            "{\"name\":\"Brokerage\",\"currency\":\"RUB\",\"type\":\"BROKERAGE\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+    given(instrumentCatalog.search(any()))
+        .willReturn(
+            java.util.List.of(
+                new InstrumentCatalog.InstrumentOption(
+                    "SBER",
+                    "Сбербанк",
+                    "ПАО Сбербанк",
+                    "RU0009029540",
+                    InstrumentCatalog.Kind.SHARE)));
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/instruments", accountId).param("q", "SBER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].symbol").value("SBER"))
+        .andExpect(jsonPath("$[0].kind").value("SHARE"));
   }
 
   @Test

--- a/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/AccountsControllerTest.java
@@ -2,6 +2,9 @@ package com.mindfulfinance.api;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -12,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.jayway.jsonpath.JsonPath;
 import com.mindfulfinance.api.config.ApiWiringConfig;
+import com.mindfulfinance.application.ports.InstrumentCatalog;
 import com.mindfulfinance.application.usecases.CreatePersonalFinanceCard;
 import com.mindfulfinance.application.usecases.SavePersonalFinanceSettings;
 import com.mindfulfinance.domain.personalfinance.PersonalFinanceCard;
@@ -21,6 +25,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -35,6 +40,7 @@ public class AccountsControllerTest {
   @Autowired MockMvc mockMvc;
   @Autowired CreatePersonalFinanceCard createPersonalFinanceCard;
   @Autowired SavePersonalFinanceSettings savePersonalFinanceSettings;
+  @MockBean InstrumentCatalog instrumentCatalog;
 
   @Test
   public void createAccount_returns201AndAccountId() throws Exception {
@@ -250,8 +256,282 @@ public class AccountsControllerTest {
     mockMvc
         .perform(get("/accounts/{accountId}/transactions", accountId))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].accountId").value(accountId))
+        .andExpect(jsonPath("$[0].accountName").value("Cash"))
         .andExpect(jsonPath("$[0].direction").value("OUTFLOW"))
         .andExpect(jsonPath("$[0].amount").value("12.34"));
+  }
+
+  @Test
+  public void createAndListTradeTransactions_forExistingAccount() throws Exception {
+    MvcResult accountResult =
+        mockMvc
+            .perform(
+                post("/accounts")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"name\":\"Brokerage\",\"currency\":\"USD\",\"type\":\"BROKERAGE\"}"))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    String accountId =
+        JsonPath.read(accountResult.getResponse().getContentAsString(), "$.accountId");
+
+    mockMvc
+        .perform(
+            post("/accounts/{accountId}/transactions", accountId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "occurredOn":"2026-02-20",
+                      "direction":"OUTFLOW",
+                      "memo":"Buy AAPL",
+                      "instrumentSymbol":"aapl",
+                      "quantity":"2",
+                      "unitPrice":"100.00",
+                      "feeAmount":"1.50"
+                    }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.transactionId").exists());
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/transactions", accountId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].accountId").value(accountId))
+        .andExpect(jsonPath("$[0].accountName").value("Brokerage"))
+        .andExpect(jsonPath("$[0].direction").value("OUTFLOW"))
+        .andExpect(jsonPath("$[0].amount").value("201.50"))
+        .andExpect(jsonPath("$[0].instrumentSymbol").value("AAPL"))
+        .andExpect(jsonPath("$[0].quantity").value("2"))
+        .andExpect(jsonPath("$[0].unitPrice").value("100.00"))
+        .andExpect(jsonPath("$[0].feeAmount").value("1.50"))
+        .andExpect(jsonPath("$[0].memo").value("Buy AAPL"));
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/balance", accountId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.amount").value("-201.50"))
+        .andExpect(jsonPath("$.currency").value("USD"));
+  }
+
+  @Test
+  public void getAccountInstruments_returnsBrokerageScopedRows() throws Exception {
+    String accountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"name\":\"Brokerage\",\"currency\":\"RUB\",\"type\":\"BROKERAGE\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+    given(instrumentCatalog.search(any()))
+        .willReturn(
+            java.util.List.of(
+                new InstrumentCatalog.InstrumentOption(
+                    "SBER",
+                    "Сбербанк",
+                    "ПАО Сбербанк",
+                    "RU0009029540",
+                    InstrumentCatalog.Kind.SHARE)));
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/instruments", accountId).param("q", "SBER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].symbol").value("SBER"))
+        .andExpect(jsonPath("$[0].shortName").value("Сбербанк"))
+        .andExpect(jsonPath("$[0].kind").value("SHARE"));
+  }
+
+  @Test
+  public void getAccountInstruments_withShortQuery_returnsEmptyArrayWithoutCallingCatalog()
+      throws Exception {
+    String accountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"name\":\"Brokerage\",\"currency\":\"RUB\",\"type\":\"BROKERAGE\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/instruments", accountId).param("q", "S"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isEmpty());
+
+    verifyNoInteractions(instrumentCatalog);
+  }
+
+  @Test
+  public void getAccountInstruments_withUnsupportedAccountType_returns400() throws Exception {
+    String accountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Cash\",\"currency\":\"USD\",\"type\":\"CASH\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/instruments", accountId).param("q", "SBER"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+        .andExpect(
+            jsonPath("$.message")
+                .value("Instrument search is supported only for BROKERAGE and IIS accounts"));
+  }
+
+  @Test
+  public void getAccountInstruments_forLinkedAccount_returns404() throws Exception {
+    PersonalFinanceCard card =
+        createPersonalFinanceCard.create(
+            new CreatePersonalFinanceCard.Command("Тестовая карта"));
+
+    mockMvc
+        .perform(
+            get("/accounts/{accountId}/instruments", card.linkedAccountId().value())
+                .param("q", "SBER"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+  }
+
+  @Test
+  public void getAccountInstruments_whenCatalogUnavailable_returns503() throws Exception {
+    String accountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"name\":\"Brokerage\",\"currency\":\"RUB\",\"type\":\"BROKERAGE\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+    given(instrumentCatalog.search(any()))
+        .willThrow(
+            new InstrumentCatalogUnavailableException(
+                "Не удалось загрузить инструменты с Московской биржи. Попробуйте позже.",
+                null));
+
+    mockMvc
+        .perform(get("/accounts/{accountId}/instruments", accountId).param("q", "SBER"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.error").value("SERVICE_UNAVAILABLE"));
+  }
+
+  @Test
+  public void listInvestmentTransactions_returnsGlobalSortedRows_andExcludesLinkedAccounts()
+      throws Exception {
+    String alphaAccountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"name\":\"Alpha Brokerage\",\"currency\":\"USD\",\"type\":\"BROKERAGE\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+    String betaAccountId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"name\":\"Beta Cash\",\"currency\":\"EUR\",\"type\":\"CASH\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.accountId");
+
+    String alphaSameDayId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts/{accountId}/transactions", alphaAccountId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"occurredOn\":\"2026-04-15\",\"direction\":\"OUTFLOW\",\"amount\":\"10.00\",\"memo\":\"Alpha same day\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.transactionId");
+    String olderAlphaId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts/{accountId}/transactions", alphaAccountId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"occurredOn\":\"2026-04-10\",\"direction\":\"INFLOW\",\"amount\":\"50.00\",\"memo\":\"Alpha older\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.transactionId");
+    String betaSameDayLaterCreatedId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    post("/accounts/{accountId}/transactions", betaAccountId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"occurredOn\":\"2026-04-15\",\"direction\":\"INFLOW\",\"amount\":\"200.00\",\"memo\":\"Beta same day\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.transactionId");
+
+    PersonalFinanceCard card =
+        createPersonalFinanceCard.create(new CreatePersonalFinanceCard.Command("Основная карта"));
+    savePersonalFinanceSettings.save(
+        new SavePersonalFinanceSettings.Command(
+            card.id(),
+            new java.math.BigDecimal("1000.00"),
+            java.util.Map.of(),
+            new java.math.BigDecimal("0.00"),
+            new java.math.BigDecimal("0.00")));
+
+    mockMvc
+        .perform(get("/investment-transactions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$[0].id").value(betaSameDayLaterCreatedId))
+        .andExpect(jsonPath("$[0].accountId").value(betaAccountId))
+        .andExpect(jsonPath("$[0].accountName").value("Beta Cash"))
+        .andExpect(jsonPath("$[1].id").value(alphaSameDayId))
+        .andExpect(jsonPath("$[1].accountId").value(alphaAccountId))
+        .andExpect(jsonPath("$[1].accountName").value("Alpha Brokerage"))
+        .andExpect(jsonPath("$[2].id").value(olderAlphaId))
+        .andExpect(jsonPath("$[2].accountId").value(alphaAccountId))
+        .andExpect(jsonPath("$[2].accountName").value("Alpha Brokerage"));
   }
 
   @Test

--- a/backend/api/src/test/java/com/mindfulfinance/api/ApiExceptionHandlerTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/ApiExceptionHandlerTest.java
@@ -66,6 +66,14 @@ public class ApiExceptionHandlerTest {
   }
 
   @Test
+  public void instrumentCatalogUnavailableException_returns503ServiceUnavailable() throws Exception {
+    mockMvc
+        .perform(get("/throw/service-unavailable"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.error").value("SERVICE_UNAVAILABLE"));
+  }
+
+  @Test
   public void duplicateKeyException_returns409Conflict() throws Exception {
     mockMvc
         .perform(get("/throw/duplicate-key"))
@@ -111,6 +119,11 @@ public class ApiExceptionHandlerTest {
     @GetMapping("/throw/bad-request")
     public String badRequest() {
       throw new IllegalArgumentException("Invalid value");
+    }
+
+    @GetMapping("/throw/service-unavailable")
+    public String serviceUnavailable() {
+      throw new InstrumentCatalogUnavailableException("MOEX is unavailable", null);
     }
 
     @GetMapping("/throw/duplicate-key")

--- a/backend/api/src/test/java/com/mindfulfinance/api/MoexInstrumentCatalogTest.java
+++ b/backend/api/src/test/java/com/mindfulfinance/api/MoexInstrumentCatalogTest.java
@@ -1,0 +1,129 @@
+package com.mindfulfinance.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.mindfulfinance.application.ports.InstrumentCatalog;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+public class MoexInstrumentCatalogTest {
+  @Test
+  public void search_filtersAndMapsShareAndFundRows() {
+    RestClient.Builder builder = RestClient.builder().baseUrl("https://iss.moex.com/iss");
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    server
+        .expect(requestTo("https://iss.moex.com/iss/securities.json?iss.meta=off&lang=en&limit=50&q=SBER"))
+        .andExpect(method(GET))
+        .andRespond(withSuccess(responseBody(), MediaType.APPLICATION_JSON));
+    MoexInstrumentCatalog catalog =
+        new MoexInstrumentCatalog(
+            builder.build(), Clock.fixed(Instant.parse("2026-04-19T12:00:00Z"), ZoneOffset.UTC), Duration.ofMinutes(15));
+
+    List<InstrumentCatalog.InstrumentOption> result =
+        catalog.search(new InstrumentCatalog.Query("SBER", InstrumentCatalog.Scope.SHARES_AND_FUNDS));
+
+    assertEquals(List.of("SBER", "TMOS"), result.stream().map(InstrumentCatalog.InstrumentOption::symbol).toList());
+    assertEquals(
+        List.of(InstrumentCatalog.Kind.SHARE, InstrumentCatalog.Kind.FUND),
+        result.stream().map(InstrumentCatalog.InstrumentOption::kind).toList());
+    server.verify();
+  }
+
+  @Test
+  public void search_filtersAndMapsBondRows() {
+    RestClient.Builder builder = RestClient.builder().baseUrl("https://iss.moex.com/iss");
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    server
+        .expect(requestTo("https://iss.moex.com/iss/securities.json?iss.meta=off&lang=en&limit=50&q=OFZ"))
+        .andExpect(method(GET))
+        .andRespond(withSuccess(responseBody(), MediaType.APPLICATION_JSON));
+    MoexInstrumentCatalog catalog =
+        new MoexInstrumentCatalog(
+            builder.build(), Clock.fixed(Instant.parse("2026-04-19T12:00:00Z"), ZoneOffset.UTC), Duration.ofMinutes(15));
+
+    List<InstrumentCatalog.InstrumentOption> result =
+        catalog.search(new InstrumentCatalog.Query("OFZ", InstrumentCatalog.Scope.BONDS));
+
+    assertEquals(List.of("SU26238RMFS4"), result.stream().map(InstrumentCatalog.InstrumentOption::symbol).toList());
+    assertEquals(InstrumentCatalog.Kind.BOND, result.getFirst().kind());
+    server.verify();
+  }
+
+  @Test
+  public void search_reusesCachedResultForSameScopeAndQuery() {
+    RestClient.Builder builder = RestClient.builder().baseUrl("https://iss.moex.com/iss");
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    server
+        .expect(requestTo("https://iss.moex.com/iss/securities.json?iss.meta=off&lang=en&limit=50&q=SBER"))
+        .andExpect(method(GET))
+        .andRespond(withSuccess(responseBody(), MediaType.APPLICATION_JSON));
+    MoexInstrumentCatalog catalog =
+        new MoexInstrumentCatalog(
+            builder.build(), Clock.fixed(Instant.parse("2026-04-19T12:00:00Z"), ZoneOffset.UTC), Duration.ofMinutes(15));
+
+    List<InstrumentCatalog.InstrumentOption> first =
+        catalog.search(new InstrumentCatalog.Query("SBER", InstrumentCatalog.Scope.SHARES_AND_FUNDS));
+    List<InstrumentCatalog.InstrumentOption> second =
+        catalog.search(new InstrumentCatalog.Query("sber", InstrumentCatalog.Scope.SHARES_AND_FUNDS));
+
+    assertEquals(first, second);
+    server.verify();
+  }
+
+  @Test
+  public void search_translatesUpstreamFailures() {
+    RestClient.Builder builder = RestClient.builder().baseUrl("https://iss.moex.com/iss");
+    MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+    server
+        .expect(requestTo("https://iss.moex.com/iss/securities.json?iss.meta=off&lang=en&limit=50&q=SBER"))
+        .andExpect(method(GET))
+        .andRespond(withServerError());
+    MoexInstrumentCatalog catalog =
+        new MoexInstrumentCatalog(
+            builder.build(), Clock.fixed(Instant.parse("2026-04-19T12:00:00Z"), ZoneOffset.UTC), Duration.ofMinutes(15));
+
+    InstrumentCatalogUnavailableException exception =
+        assertThrows(
+            InstrumentCatalogUnavailableException.class,
+            () ->
+                catalog.search(
+                    new InstrumentCatalog.Query(
+                        "SBER", InstrumentCatalog.Scope.SHARES_AND_FUNDS)));
+
+    assertEquals(
+        "Не удалось загрузить инструменты с Московской биржи. Попробуйте позже.",
+        exception.getMessage());
+    server.verify();
+  }
+
+  private static String responseBody() {
+    return """
+        {
+          "securities": {
+            "columns": ["secid","shortname","name","isin","is_traded","group","primary_boardid"],
+            "data": [
+              ["SBER","Сбербанк","ПАО Сбербанк","RU0009029540",1,"stock_shares","TQBR"],
+              ["TMOS","Тинькофф IMOEX","БПИФ TMOS","RU000A101X76",1,"stock_ppif","TQTF"],
+              ["TMOSA","IMOEX Index","IMOEX","",1,"stock_index","INAV"],
+              ["SU26238RMFS4","ОФЗ 26238","ОФЗ-ПД 26238","RU000A1038V6",1,"stock_bonds","TQOB"],
+              ["SBER","Сбербанк дубль","ПАО Сбербанк","RU0009029540",1,"stock_shares","TQBR"],
+              ["OLD","Не торгуется","Не торгуется","RU0000000000",0,"stock_shares","TQBR"]
+            ]
+          }
+        }
+        """;
+  }
+}

--- a/backend/application/src/main/java/com/mindfulfinance/application/ports/InstrumentCatalog.java
+++ b/backend/application/src/main/java/com/mindfulfinance/application/ports/InstrumentCatalog.java
@@ -1,0 +1,22 @@
+package com.mindfulfinance.application.ports;
+
+import java.util.List;
+
+public interface InstrumentCatalog {
+  List<InstrumentOption> search(Query query);
+
+  record Query(String text, Scope scope) {}
+
+  enum Scope {
+    SHARES_AND_FUNDS,
+    BONDS
+  }
+
+  enum Kind {
+    SHARE,
+    FUND,
+    BOND
+  }
+
+  record InstrumentOption(String symbol, String shortName, String name, String isin, Kind kind) {}
+}

--- a/backend/application/src/main/java/com/mindfulfinance/application/usecases/ListInvestmentTransactions.java
+++ b/backend/application/src/main/java/com/mindfulfinance/application/usecases/ListInvestmentTransactions.java
@@ -1,0 +1,51 @@
+package com.mindfulfinance.application.usecases;
+
+import com.mindfulfinance.application.ports.AccountRepository;
+import com.mindfulfinance.application.ports.PersonalFinanceCardRepository;
+import com.mindfulfinance.application.ports.TransactionRepository;
+import com.mindfulfinance.domain.account.Account;
+import com.mindfulfinance.domain.account.AccountId;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCard;
+import com.mindfulfinance.domain.transaction.Transaction;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class ListInvestmentTransactions {
+  private static final Comparator<ResultRow> RESULT_ORDER =
+      Comparator.comparing((ResultRow row) -> row.transaction().occurredOn()).reversed()
+          .thenComparing(
+              (ResultRow row) -> row.transaction().createdAt(), Comparator.reverseOrder())
+          .thenComparing(row -> row.transaction().id().value().toString());
+
+  private final AccountRepository accounts;
+  private final PersonalFinanceCardRepository cards;
+  private final TransactionRepository transactions;
+
+  public ListInvestmentTransactions(
+      AccountRepository accounts,
+      PersonalFinanceCardRepository cards,
+      TransactionRepository transactions) {
+    this.accounts = accounts;
+    this.cards = cards;
+    this.transactions = transactions;
+  }
+
+  public java.util.List<ResultRow> list() {
+    Set<AccountId> linkedAccountIds =
+        cards.findAll().stream()
+            .map(PersonalFinanceCard::linkedAccountId)
+            .collect(Collectors.toSet());
+
+    return accounts.findAll().stream()
+        .filter(account -> !linkedAccountIds.contains(account.id()))
+        .flatMap(
+            account ->
+                transactions.findByAccountId(account.id()).stream()
+                    .map(transaction -> new ResultRow(account, transaction)))
+        .sorted(RESULT_ORDER)
+        .toList();
+  }
+
+  public record ResultRow(Account account, Transaction transaction) {}
+}

--- a/backend/application/src/main/java/com/mindfulfinance/application/usecases/SearchAccountInstruments.java
+++ b/backend/application/src/main/java/com/mindfulfinance/application/usecases/SearchAccountInstruments.java
@@ -1,0 +1,57 @@
+package com.mindfulfinance.application.usecases;
+
+import com.mindfulfinance.application.ports.AccountRepository;
+import com.mindfulfinance.application.ports.InstrumentCatalog;
+import com.mindfulfinance.application.ports.PersonalFinanceCardRepository;
+import com.mindfulfinance.domain.account.Account;
+import com.mindfulfinance.domain.account.AccountId;
+import com.mindfulfinance.domain.account.AccountType;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class SearchAccountInstruments {
+  private static final String UNSUPPORTED_ACCOUNT_TYPE_MESSAGE =
+      "Instrument search is supported only for BROKERAGE and IIS accounts";
+
+  private final AccountRepository accounts;
+  private final PersonalFinanceCardRepository cards;
+  private final InstrumentCatalog instrumentCatalog;
+
+  public SearchAccountInstruments(
+      AccountRepository accounts,
+      PersonalFinanceCardRepository cards,
+      InstrumentCatalog instrumentCatalog) {
+    this.accounts = accounts;
+    this.cards = cards;
+    this.instrumentCatalog = instrumentCatalog;
+  }
+
+  public Optional<List<InstrumentCatalog.InstrumentOption>> search(Command command) {
+    Objects.requireNonNull(command, "command");
+
+    Account account = accounts.find(command.accountId()).orElse(null);
+    if (account == null || cards.findByLinkedAccountId(account.id()).isPresent()) {
+      return Optional.empty();
+    }
+
+    String normalizedQuery = command.query() == null ? "" : command.query().trim();
+    if (normalizedQuery.length() < 2) {
+      return Optional.of(List.of());
+    }
+
+    return Optional.of(
+        instrumentCatalog.search(
+            new InstrumentCatalog.Query(normalizedQuery, toScope(account.type()))));
+  }
+
+  private static InstrumentCatalog.Scope toScope(AccountType type) {
+    return switch (type) {
+      case BROKERAGE -> InstrumentCatalog.Scope.SHARES_AND_FUNDS;
+      case IIS -> InstrumentCatalog.Scope.BONDS;
+      default -> throw new IllegalArgumentException(UNSUPPORTED_ACCOUNT_TYPE_MESSAGE);
+    };
+  }
+
+  public record Command(AccountId accountId, String query) {}
+}

--- a/backend/application/src/main/java/com/mindfulfinance/application/usecases/UpdateTransaction.java
+++ b/backend/application/src/main/java/com/mindfulfinance/application/usecases/UpdateTransaction.java
@@ -6,6 +6,7 @@ import com.mindfulfinance.domain.money.Money;
 import com.mindfulfinance.domain.transaction.Transaction;
 import com.mindfulfinance.domain.transaction.TransactionDirection;
 import com.mindfulfinance.domain.transaction.TransactionId;
+import com.mindfulfinance.domain.transaction.TransactionTrade;
 import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.List;
@@ -24,6 +25,16 @@ public final class UpdateTransaction {
 
   public Optional<Transaction> update(Command command) {
     List<Transaction> existingTransactions = transactions.findByAccountId(command.accountId());
+    TransactionTrade trade =
+        Transaction.trade(
+            command.instrumentSymbol(),
+            command.quantity(),
+            toMoney(command.unitPrice(), command.currency()),
+            toMoney(command.feeAmount(), command.currency()));
+    Money amount =
+        trade == null
+            ? new Money(command.amount(), command.currency())
+            : trade.cashAmount(command.direction());
 
     Transaction currentTransaction =
         existingTransactions.stream()
@@ -44,9 +55,10 @@ public final class UpdateTransaction {
                     !transaction.id().equals(command.transactionId())
                         && transaction.occurredOn().equals(command.occurredOn())
                         && transaction.direction() == command.direction()
-                        && transaction.amount().amount().compareTo(command.amount()) == 0
-                        && transaction.amount().currency().equals(command.currency())
-                        && memoEqualsIgnoreCase(transaction.memo(), normalizedMemo));
+                        && transaction.amount().amount().compareTo(amount.amount()) == 0
+                        && transaction.amount().currency().equals(amount.currency())
+                        && memoEqualsIgnoreCase(transaction.memo(), normalizedMemo)
+                        && Objects.equals(transaction.trade(), trade));
 
     if (isDuplicate) {
       throw new IllegalStateException(DUPLICATE_TRANSACTION_MESSAGE);
@@ -58,12 +70,20 @@ public final class UpdateTransaction {
             currentTransaction.accountId(),
             command.occurredOn(),
             command.direction(),
-            new Money(command.amount(), command.currency()),
+            amount,
             normalizedMemo,
-            currentTransaction.createdAt());
+            currentTransaction.createdAt(),
+            trade);
 
     transactions.update(updatedTransaction);
     return Optional.of(updatedTransaction);
+  }
+
+  private static Money toMoney(BigDecimal amount, Currency currency) {
+    if (amount == null || currency == null) {
+      return null;
+    }
+    return new Money(amount, currency);
   }
 
   private static boolean memoEqualsIgnoreCase(String left, String right) {
@@ -87,5 +107,9 @@ public final class UpdateTransaction {
       java.time.LocalDate occurredOn,
       TransactionDirection direction,
       BigDecimal amount,
-      String memo) {}
+      String memo,
+      String instrumentSymbol,
+      BigDecimal quantity,
+      BigDecimal unitPrice,
+      BigDecimal feeAmount) {}
 }

--- a/backend/application/src/test/java/com/mindfulfinance/application/usecases/ListInvestmentTransactionsTest.java
+++ b/backend/application/src/test/java/com/mindfulfinance/application/usecases/ListInvestmentTransactionsTest.java
@@ -1,0 +1,221 @@
+package com.mindfulfinance.application.usecases;
+
+import static com.mindfulfinance.domain.account.AccountStatus.ACTIVE;
+import static com.mindfulfinance.domain.account.AccountType.BROKERAGE;
+import static com.mindfulfinance.domain.account.AccountType.CASH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mindfulfinance.application.ports.InMemoryAccountRepository;
+import com.mindfulfinance.application.ports.InMemoryTransactionRepository;
+import com.mindfulfinance.application.ports.PersonalFinanceCardRepository;
+import com.mindfulfinance.domain.account.Account;
+import com.mindfulfinance.domain.account.AccountId;
+import com.mindfulfinance.domain.money.Money;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCard;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCardId;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCardStatus;
+import com.mindfulfinance.domain.transaction.Transaction;
+import com.mindfulfinance.domain.transaction.TransactionDirection;
+import com.mindfulfinance.domain.transaction.TransactionId;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Currency;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ListInvestmentTransactionsTest {
+  private final InMemoryAccountRepository accounts = new InMemoryAccountRepository();
+  private final InMemoryTransactionRepository transactions = new InMemoryTransactionRepository();
+  private final InMemoryCardRepository cards = new InMemoryCardRepository();
+  private final ListInvestmentTransactions useCase =
+      new ListInvestmentTransactions(accounts, cards, transactions);
+
+  @Test
+  @DisplayName("Returns global investment transactions sorted newest-first and excludes linked accounts")
+  void returnsGlobalInvestmentTransactionsSortedNewestFirstAndExcludesLinkedAccounts() {
+    Account firstAccount = account("Alpha Broker", "USD", BROKERAGE);
+    Account secondAccount = account("Beta Cash", "EUR", CASH);
+    Account linkedAccount = account("Hidden Linked", "RUB", CASH);
+    accounts.save(firstAccount);
+    accounts.save(secondAccount);
+    accounts.save(linkedAccount);
+
+    cards.save(
+        new PersonalFinanceCard(
+            PersonalFinanceCardId.random(),
+            "Основная карта",
+            linkedAccount.id(),
+            Instant.parse("2026-01-01T10:00:00Z"),
+            PersonalFinanceCardStatus.ACTIVE));
+
+    Transaction newest =
+        transaction(
+            secondAccount.id(),
+            "2026-04-15",
+            "2026-04-15T18:30:00Z",
+            "200.00",
+            "EUR",
+            TransactionDirection.INFLOW,
+            "Sell");
+    Transaction sameDayEarlierCreatedAt =
+        transaction(
+            firstAccount.id(),
+            "22222222-2222-2222-2222-222222222222",
+            "2026-04-15",
+            "2026-04-15T09:00:00Z",
+            "10.00",
+            "USD",
+            TransactionDirection.OUTFLOW,
+            "Buy");
+    Transaction sameDaySameCreatedAtHigherId =
+        transaction(
+            firstAccount.id(),
+            "11111111-1111-1111-1111-111111111111",
+            "2026-04-15",
+            "2026-04-15T09:00:00Z",
+            "15.00",
+            "USD",
+            TransactionDirection.OUTFLOW,
+            "Buy 2");
+    Transaction sameDaySameCreatedAtLowerId =
+        transaction(
+            firstAccount.id(),
+            "00000000-0000-0000-0000-000000000000",
+            "2026-04-15",
+            "2026-04-15T09:00:00Z",
+            "12.00",
+            "USD",
+            TransactionDirection.OUTFLOW,
+            "Buy 3");
+    Transaction older =
+        transaction(
+            firstAccount.id(),
+            "2026-04-10",
+            "2026-04-10T09:00:00Z",
+            "50.00",
+            "USD",
+            TransactionDirection.INFLOW,
+            "Dividend");
+    Transaction hidden =
+        transaction(
+            linkedAccount.id(),
+            "2026-04-16",
+            "2026-04-16T09:00:00Z",
+            "1000.00",
+            "RUB",
+            TransactionDirection.INFLOW,
+            "Hidden");
+
+    transactions.save(older);
+    transactions.save(sameDayEarlierCreatedAt);
+    transactions.save(newest);
+    transactions.save(hidden);
+    transactions.save(sameDaySameCreatedAtHigherId);
+    transactions.save(sameDaySameCreatedAtLowerId);
+
+    List<ListInvestmentTransactions.ResultRow> rows = useCase.list();
+
+    assertEquals(
+        List.of(
+            newest.id(),
+            sameDaySameCreatedAtLowerId.id(),
+            sameDaySameCreatedAtHigherId.id(),
+            sameDayEarlierCreatedAt.id(),
+            older.id()),
+        rows.stream().map(row -> row.transaction().id()).toList());
+    assertEquals(
+        List.of(
+            secondAccount.id(),
+            firstAccount.id(),
+            firstAccount.id(),
+            firstAccount.id(),
+            firstAccount.id()),
+        rows.stream().map(row -> row.account().id()).toList());
+    assertEquals(
+        List.of("Beta Cash", "Alpha Broker", "Alpha Broker", "Alpha Broker", "Alpha Broker"),
+        rows.stream().map(row -> row.account().name()).toList());
+  }
+
+  private static Account account(String name, String currency, com.mindfulfinance.domain.account.AccountType type) {
+    return new Account(
+        AccountId.random(),
+        name,
+        Currency.getInstance(currency),
+        type,
+        ACTIVE,
+        Instant.parse("2026-01-01T10:00:00Z"));
+  }
+
+  private static Transaction transaction(
+      AccountId accountId,
+      String occurredOn,
+      String createdAt,
+      String amount,
+      String currency,
+      TransactionDirection direction,
+      String memo) {
+    return new Transaction(
+        TransactionId.random(),
+        accountId,
+        LocalDate.parse(occurredOn),
+        direction,
+        new Money(new BigDecimal(amount), Currency.getInstance(currency)),
+        memo,
+        Instant.parse(createdAt));
+  }
+
+  private static Transaction transaction(
+      AccountId accountId,
+      String transactionId,
+      String occurredOn,
+      String createdAt,
+      String amount,
+      String currency,
+      TransactionDirection direction,
+      String memo) {
+    return new Transaction(
+        new TransactionId(java.util.UUID.fromString(transactionId)),
+        accountId,
+        LocalDate.parse(occurredOn),
+        direction,
+        new Money(new BigDecimal(amount), Currency.getInstance(currency)),
+        memo,
+        Instant.parse(createdAt));
+  }
+
+  private static final class InMemoryCardRepository implements PersonalFinanceCardRepository {
+    private final Map<PersonalFinanceCardId, PersonalFinanceCard> store = new LinkedHashMap<>();
+
+    @Override
+    public Optional<PersonalFinanceCard> find(PersonalFinanceCardId id) {
+      return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<PersonalFinanceCard> findByLinkedAccountId(AccountId linkedAccountId) {
+      return store.values().stream()
+          .filter(card -> card.linkedAccountId().equals(linkedAccountId))
+          .findFirst();
+    }
+
+    @Override
+    public List<PersonalFinanceCard> findAll() {
+      return List.copyOf(store.values());
+    }
+
+    @Override
+    public void save(PersonalFinanceCard card) {
+      store.put(card.id(), card);
+    }
+
+    @Override
+    public void delete(PersonalFinanceCardId id) {
+      store.remove(id);
+    }
+  }
+}

--- a/backend/application/src/test/java/com/mindfulfinance/application/usecases/SearchAccountInstrumentsTest.java
+++ b/backend/application/src/test/java/com/mindfulfinance/application/usecases/SearchAccountInstrumentsTest.java
@@ -1,0 +1,183 @@
+package com.mindfulfinance.application.usecases;
+
+import static com.mindfulfinance.domain.account.AccountStatus.ACTIVE;
+import static com.mindfulfinance.domain.account.AccountType.BROKERAGE;
+import static com.mindfulfinance.domain.account.AccountType.CASH;
+import static com.mindfulfinance.domain.account.AccountType.IIS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mindfulfinance.application.ports.InMemoryAccountRepository;
+import com.mindfulfinance.application.ports.InstrumentCatalog;
+import com.mindfulfinance.application.ports.PersonalFinanceCardRepository;
+import com.mindfulfinance.domain.account.Account;
+import com.mindfulfinance.domain.account.AccountId;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCard;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCardId;
+import com.mindfulfinance.domain.personalfinance.PersonalFinanceCardStatus;
+import java.time.Instant;
+import java.util.Currency;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SearchAccountInstrumentsTest {
+  private final InMemoryAccountRepository accounts = new InMemoryAccountRepository();
+  private final InMemoryCardRepository cards = new InMemoryCardRepository();
+  private final StubInstrumentCatalog instrumentCatalog = new StubInstrumentCatalog();
+  private final SearchAccountInstruments useCase =
+      new SearchAccountInstruments(accounts, cards, instrumentCatalog);
+
+  @Test
+  @DisplayName("Searches shares and funds for brokerage accounts")
+  void searchesSharesAndFundsForBrokerageAccounts() {
+    Account account = account("Broker", "RUB", BROKERAGE);
+    accounts.save(account);
+    instrumentCatalog.nextResults =
+        List.of(
+            new InstrumentCatalog.InstrumentOption(
+                "SBER", "Сбербанк", "ПАО Сбербанк", "RU0009029540", InstrumentCatalog.Kind.SHARE));
+
+    List<InstrumentCatalog.InstrumentOption> result =
+        useCase
+            .search(new SearchAccountInstruments.Command(account.id(), " sber "))
+            .orElseThrow();
+
+    assertEquals(InstrumentCatalog.Scope.SHARES_AND_FUNDS, instrumentCatalog.lastQuery.scope());
+    assertEquals("sber", instrumentCatalog.lastQuery.text());
+    assertEquals("SBER", result.getFirst().symbol());
+  }
+
+  @Test
+  @DisplayName("Searches bonds for IIS accounts")
+  void searchesBondsForIisAccounts() {
+    Account account = account("IIS", "RUB", IIS);
+    accounts.save(account);
+    instrumentCatalog.nextResults =
+        List.of(
+            new InstrumentCatalog.InstrumentOption(
+                "SU26238RMFS4",
+                "ОФЗ 26238",
+                "ОФЗ-ПД 26238",
+                "RU000A1038V6",
+                InstrumentCatalog.Kind.BOND));
+
+    List<InstrumentCatalog.InstrumentOption> result =
+        useCase.search(new SearchAccountInstruments.Command(account.id(), "OFZ")).orElseThrow();
+
+    assertEquals(InstrumentCatalog.Scope.BONDS, instrumentCatalog.lastQuery.scope());
+    assertEquals("OFZ", instrumentCatalog.lastQuery.text());
+    assertEquals("SU26238RMFS4", result.getFirst().symbol());
+  }
+
+  @Test
+  @DisplayName("Returns empty results for short queries without touching the catalog")
+  void returnsEmptyResultsForShortQueriesWithoutTouchingCatalog() {
+    Account account = account("Broker", "RUB", BROKERAGE);
+    accounts.save(account);
+
+    List<InstrumentCatalog.InstrumentOption> result =
+        useCase.search(new SearchAccountInstruments.Command(account.id(), "s")).orElseThrow();
+
+    assertTrue(result.isEmpty());
+    assertEquals(0, instrumentCatalog.searchCalls);
+  }
+
+  @Test
+  @DisplayName("Returns empty optional for missing or linked accounts")
+  void returnsEmptyOptionalForMissingOrLinkedAccounts() {
+    Account linkedAccount = account("Linked", "RUB", BROKERAGE);
+    accounts.save(linkedAccount);
+    cards.save(
+        new PersonalFinanceCard(
+            PersonalFinanceCardId.random(),
+            "Карта",
+            linkedAccount.id(),
+            Instant.parse("2026-01-01T10:00:00Z"),
+            PersonalFinanceCardStatus.ACTIVE));
+
+    assertTrue(
+        useCase.search(new SearchAccountInstruments.Command(AccountId.random(), "SBER")).isEmpty());
+    assertTrue(
+        useCase
+            .search(new SearchAccountInstruments.Command(linkedAccount.id(), "SBER"))
+            .isEmpty());
+    assertEquals(0, instrumentCatalog.searchCalls);
+  }
+
+  @Test
+  @DisplayName("Rejects unsupported account types")
+  void rejectsUnsupportedAccountTypes() {
+    Account cashAccount = account("Cash", "USD", CASH);
+    accounts.save(cashAccount);
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                useCase.search(new SearchAccountInstruments.Command(cashAccount.id(), "SBER")));
+
+    assertEquals(
+        "Instrument search is supported only for BROKERAGE and IIS accounts",
+        exception.getMessage());
+  }
+
+  private static Account account(
+      String name, String currency, com.mindfulfinance.domain.account.AccountType type) {
+    return new Account(
+        AccountId.random(),
+        name,
+        Currency.getInstance(currency),
+        type,
+        ACTIVE,
+        Instant.parse("2026-01-01T10:00:00Z"));
+  }
+
+  private static final class StubInstrumentCatalog implements InstrumentCatalog {
+    private Query lastQuery;
+    private int searchCalls;
+    private List<InstrumentOption> nextResults = List.of();
+
+    @Override
+    public List<InstrumentOption> search(Query query) {
+      searchCalls += 1;
+      lastQuery = query;
+      return nextResults;
+    }
+  }
+
+  private static final class InMemoryCardRepository implements PersonalFinanceCardRepository {
+    private final Map<PersonalFinanceCardId, PersonalFinanceCard> store = new LinkedHashMap<>();
+
+    @Override
+    public Optional<PersonalFinanceCard> find(PersonalFinanceCardId id) {
+      return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<PersonalFinanceCard> findByLinkedAccountId(AccountId linkedAccountId) {
+      return store.values().stream()
+          .filter(card -> card.linkedAccountId().equals(linkedAccountId))
+          .findFirst();
+    }
+
+    @Override
+    public List<PersonalFinanceCard> findAll() {
+      return List.copyOf(store.values());
+    }
+
+    @Override
+    public void save(PersonalFinanceCard card) {
+      store.put(card.id(), card);
+    }
+
+    @Override
+    public void delete(PersonalFinanceCardId id) {
+      store.remove(id);
+    }
+  }
+}

--- a/backend/application/src/test/java/com/mindfulfinance/application/usecases/UpdateTransactionTest.java
+++ b/backend/application/src/test/java/com/mindfulfinance/application/usecases/UpdateTransactionTest.java
@@ -14,6 +14,7 @@ import com.mindfulfinance.domain.money.Money;
 import com.mindfulfinance.domain.transaction.Transaction;
 import com.mindfulfinance.domain.transaction.TransactionDirection;
 import com.mindfulfinance.domain.transaction.TransactionId;
+import com.mindfulfinance.domain.transaction.TransactionTrade;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -53,7 +54,11 @@ public class UpdateTransactionTest {
                 LocalDate.parse("2026-03-03"),
                 INFLOW,
                 new BigDecimal("75.50"),
-                "   "));
+                "   ",
+                null,
+                null,
+                null,
+                null));
 
     assertTrue(updated.isPresent());
     assertEquals(transactionId, updated.get().id());
@@ -82,7 +87,11 @@ public class UpdateTransactionTest {
                 LocalDate.parse("2026-03-03"),
                 INFLOW,
                 new BigDecimal("75.50"),
-                "Salary"));
+                "Salary",
+                null,
+                null,
+                null,
+                null));
 
     assertNotNull(updated);
     assertTrue(updated.isEmpty());
@@ -127,13 +136,58 @@ public class UpdateTransactionTest {
                         LocalDate.parse("2026-03-01"),
                         INFLOW,
                         new BigDecimal("100.00"),
-                        "bonus")));
+                        "bonus",
+                        null,
+                        null,
+                        null,
+                        null)));
 
     assertEquals(
         "Transaction with same date, direction, amount, and memo already exists",
         exception.getMessage());
     assertEquals(first, transactions.findByAccountId(accountId).get(0));
     assertEquals(second, transactions.findByAccountId(accountId).get(1));
+  }
+
+  @Test
+  @DisplayName("Should derive amount from trade details when updating transaction")
+  void shouldDeriveAmountFromTradeDetailsWhenUpdatingTransaction() {
+    AccountId accountId = AccountId.random();
+    TransactionId transactionId = TransactionId.random();
+    Instant createdAt = Instant.parse("2026-03-01T10:15:30Z");
+    Transaction original =
+        transaction(
+            transactionId,
+            accountId,
+            "2026-03-01",
+            OUTFLOW,
+            "25.00",
+            "USD",
+            "Initial",
+            createdAt);
+    transactions.save(original);
+
+    Optional<Transaction> updated =
+        useCase.update(
+            new UpdateTransaction.Command(
+                accountId,
+                transactionId,
+                Currency.getInstance("USD"),
+                LocalDate.parse("2026-03-03"),
+                OUTFLOW,
+                null,
+                "Buy AAPL",
+                "aapl",
+                new BigDecimal("2"),
+                new BigDecimal("100.00"),
+                new BigDecimal("1.50")));
+
+    assertTrue(updated.isPresent());
+    assertEquals(new BigDecimal("201.50"), updated.get().amount().amount());
+    assertEquals("AAPL", updated.get().trade().instrumentSymbol());
+    assertEquals(new BigDecimal("2"), updated.get().trade().quantity());
+    assertEquals(new BigDecimal("100.00"), updated.get().trade().unitPrice().amount());
+    assertEquals(new BigDecimal("1.50"), updated.get().trade().feeAmount().amount());
   }
 
   private static Transaction transaction(

--- a/backend/domain/src/main/java/com/mindfulfinance/domain/shared/DomainErrorCode.java
+++ b/backend/domain/src/main/java/com/mindfulfinance/domain/shared/DomainErrorCode.java
@@ -63,6 +63,27 @@ public enum DomainErrorCode {
   /** Indicates that a Transaction was created with a null createdAt timestamp. */
   TRANSACTION_CREATED_AT_NULL,
 
+  /** Indicates that investment trade details are incomplete. */
+  TRANSACTION_TRADE_FIELDS_INCOMPLETE,
+
+  /** Indicates that investment trade symbol is null or blank. */
+  TRANSACTION_TRADE_INSTRUMENT_SYMBOL_NULL_OR_BLANK,
+
+  /** Indicates that investment trade quantity is null, negative, or zero. */
+  TRANSACTION_TRADE_QUANTITY_NULL_OR_NEGATIVE_OR_ZERO,
+
+  /** Indicates that investment trade unit price is null, negative, or zero. */
+  TRANSACTION_TRADE_UNIT_PRICE_NULL_OR_NEGATIVE_OR_ZERO,
+
+  /** Indicates that investment trade fee is null or negative. */
+  TRANSACTION_TRADE_FEE_NULL_OR_NEGATIVE,
+
+  /** Indicates that investment trade monetary fields use different currencies. */
+  TRANSACTION_TRADE_CURRENCY_MISMATCH,
+
+  /** Indicates that transaction cash amount does not match trade details. */
+  TRANSACTION_TRADE_AMOUNT_MISMATCH,
+
   /** Indicates that a LifeGoal was created with a null id. */
   LIFEGOAL_ID_NULL,
 

--- a/backend/domain/src/main/java/com/mindfulfinance/domain/transaction/Transaction.java
+++ b/backend/domain/src/main/java/com/mindfulfinance/domain/transaction/Transaction.java
@@ -6,12 +6,15 @@ import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_CREAT
 import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_DIRECTION_NULL;
 import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_ID_NULL;
 import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_OCCURRED_ON_NULL;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_AMOUNT_MISMATCH;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_FIELDS_INCOMPLETE;
 
 import com.mindfulfinance.domain.account.AccountId;
 import com.mindfulfinance.domain.money.Money;
 import com.mindfulfinance.domain.shared.DomainException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Map;
 
 /**
  * Represents a financial transaction associated with an account. This class is immutable and
@@ -24,7 +27,19 @@ public record Transaction(
     TransactionDirection direction,
     Money amount,
     String memo,
-    Instant createdAt) {
+    Instant createdAt,
+    TransactionTrade trade) {
+  public Transaction(
+      TransactionId id,
+      AccountId accountId,
+      LocalDate occurredOn,
+      TransactionDirection direction,
+      Money amount,
+      String memo,
+      Instant createdAt) {
+    this(id, accountId, occurredOn, direction, amount, memo, createdAt, null);
+  }
+
   /**
    * Constructs a new Transaction with the given parameters.
    *
@@ -36,6 +51,7 @@ public record Transaction(
    * @param amount the amount of money involved in the Transaction, must not be null
    * @param memo an optional memo or note about the Transaction, can be null
    * @param createdAt the timestamp when the Transaction was created, must not be null
+   * @param trade optional investment trade details associated with the Transaction
    */
   public Transaction {
     if (memo != null) {
@@ -71,6 +87,37 @@ public record Transaction(
       throw new DomainException(
           TRANSACTION_CREATED_AT_NULL, "Transaction createdAt cannot be null", null);
     }
+
+    if (trade != null) {
+      Money derivedAmount = trade.cashAmount(direction);
+      if (!amount.currency().equals(derivedAmount.currency())
+          || amount.amount().compareTo(derivedAmount.amount()) != 0) {
+        throw new DomainException(
+            TRANSACTION_TRADE_AMOUNT_MISMATCH,
+            "Transaction amount must match trade cash effect",
+            Map.of("amount", amount, "derivedAmount", derivedAmount, "trade", trade));
+      }
+    }
+  }
+
+  public static TransactionTrade trade(
+      String instrumentSymbol, java.math.BigDecimal quantity, Money unitPrice, Money feeAmount) {
+    boolean hasAnyTradeField =
+        instrumentSymbol != null || quantity != null || unitPrice != null || feeAmount != null;
+    boolean hasAllTradeFields =
+        instrumentSymbol != null && quantity != null && unitPrice != null && feeAmount != null;
+
+    if (!hasAnyTradeField) {
+      return null;
+    }
+    if (!hasAllTradeFields) {
+      throw new DomainException(
+          TRANSACTION_TRADE_FIELDS_INCOMPLETE,
+          "Transaction trade requires instrumentSymbol, quantity, unitPrice, and feeAmount",
+          null);
+    }
+
+    return new TransactionTrade(instrumentSymbol, quantity, unitPrice, feeAmount);
   }
 
   /**

--- a/backend/domain/src/main/java/com/mindfulfinance/domain/transaction/TransactionTrade.java
+++ b/backend/domain/src/main/java/com/mindfulfinance/domain/transaction/TransactionTrade.java
@@ -1,0 +1,67 @@
+package com.mindfulfinance.domain.transaction;
+
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_CURRENCY_MISMATCH;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_FEE_NULL_OR_NEGATIVE;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_INSTRUMENT_SYMBOL_NULL_OR_BLANK;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_QUANTITY_NULL_OR_NEGATIVE_OR_ZERO;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_UNIT_PRICE_NULL_OR_NEGATIVE_OR_ZERO;
+
+import com.mindfulfinance.domain.money.Money;
+import com.mindfulfinance.domain.shared.DomainException;
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.Map;
+
+/** Investment-specific trade details attached to a transaction. */
+public record TransactionTrade(
+    String instrumentSymbol, BigDecimal quantity, Money unitPrice, Money feeAmount) {
+  public TransactionTrade {
+    if (instrumentSymbol == null || instrumentSymbol.isBlank()) {
+      throw new DomainException(
+          TRANSACTION_TRADE_INSTRUMENT_SYMBOL_NULL_OR_BLANK,
+          "Transaction trade instrumentSymbol cannot be null or blank",
+          null);
+    }
+    if (quantity == null || quantity.signum() <= 0) {
+      throw new DomainException(
+          TRANSACTION_TRADE_QUANTITY_NULL_OR_NEGATIVE_OR_ZERO,
+          "Transaction trade quantity cannot be null or negative/zero",
+          Map.of("quantity", quantity));
+    }
+    if (unitPrice == null || unitPrice.isNegative() || unitPrice.isZero()) {
+      throw new DomainException(
+          TRANSACTION_TRADE_UNIT_PRICE_NULL_OR_NEGATIVE_OR_ZERO,
+          "Transaction trade unitPrice cannot be null or negative/zero",
+          Map.of("unitPrice", unitPrice));
+    }
+    if (feeAmount == null || feeAmount.isNegative()) {
+      throw new DomainException(
+          TRANSACTION_TRADE_FEE_NULL_OR_NEGATIVE,
+          "Transaction trade feeAmount cannot be null or negative",
+          Map.of("feeAmount", feeAmount));
+    }
+    if (!unitPrice.currency().equals(feeAmount.currency())) {
+      throw new DomainException(
+          TRANSACTION_TRADE_CURRENCY_MISMATCH,
+          "Transaction trade unitPrice and feeAmount must use the same currency",
+          Map.of(
+              "unitPriceCurrency", unitPrice.currency(), "feeAmountCurrency", feeAmount.currency()));
+    }
+
+    instrumentSymbol = instrumentSymbol.trim().toUpperCase(Locale.ROOT);
+    quantity = quantity.stripTrailingZeros();
+  }
+
+  public Money cashAmount(TransactionDirection direction) {
+    Money gross = new Money(normalizeDecimal(unitPrice.amount().multiply(quantity)), unitPrice.currency());
+    return direction == TransactionDirection.OUTFLOW ? gross.add(feeAmount) : gross.subtract(feeAmount);
+  }
+
+  private static BigDecimal normalizeDecimal(BigDecimal value) {
+    BigDecimal normalized = value.stripTrailingZeros();
+    if (normalized.scale() < 0) {
+      return normalized.setScale(0);
+    }
+    return normalized;
+  }
+}

--- a/backend/domain/src/test/java/com/mindfulfinance/domain/transaction/TransactionTest.java
+++ b/backend/domain/src/test/java/com/mindfulfinance/domain/transaction/TransactionTest.java
@@ -6,6 +6,8 @@ import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_CREAT
 import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_DIRECTION_NULL;
 import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_ID_NULL;
 import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_OCCURRED_ON_NULL;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_AMOUNT_MISMATCH;
+import static com.mindfulfinance.domain.shared.DomainErrorCode.TRANSACTION_TRADE_FIELDS_INCOMPLETE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -258,5 +260,74 @@ public class TransactionTest {
             Instant.now());
     assertNotNull(transaction);
     assertNull(transaction.memo()); // Memo should be null
+  }
+
+  @Test
+  @DisplayName("Should create investment trade transaction with derived cash effect")
+  void shouldCreateTradeTransactionWithDerivedCashEffect() {
+    TransactionTrade trade =
+        Transaction.trade(
+            "  aapl ",
+            new BigDecimal("2"),
+            new Money(new BigDecimal("100.00"), Currency.getInstance("USD")),
+            new Money(new BigDecimal("1.50"), Currency.getInstance("USD")));
+
+    Transaction transaction =
+        new Transaction(
+            TransactionId.random(),
+            AccountId.random(),
+            LocalDate.now(),
+            TransactionDirection.OUTFLOW,
+            new Money(new BigDecimal("201.50"), Currency.getInstance("USD")),
+            "Buy shares",
+            Instant.now(),
+            trade);
+
+    assertNotNull(transaction.trade());
+    assertEquals("AAPL", transaction.trade().instrumentSymbol());
+    assertEquals(new BigDecimal("2"), transaction.trade().quantity());
+  }
+
+  @Test
+  @DisplayName("Should reject incomplete trade fields")
+  void shouldRejectIncompleteTradeFields() {
+    DomainException exception =
+        assertThrows(
+            DomainException.class,
+            () ->
+                Transaction.trade(
+                    "AAPL",
+                    new BigDecimal("2"),
+                    new Money(new BigDecimal("100.00"), Currency.getInstance("USD")),
+                    null));
+
+    assertEquals(TRANSACTION_TRADE_FIELDS_INCOMPLETE, exception.code());
+  }
+
+  @Test
+  @DisplayName("Should reject amount mismatch against trade cash effect")
+  void shouldRejectTradeAmountMismatch() {
+    TransactionTrade trade =
+        Transaction.trade(
+            "AAPL",
+            new BigDecimal("2"),
+            new Money(new BigDecimal("100.00"), Currency.getInstance("USD")),
+            new Money(new BigDecimal("1.50"), Currency.getInstance("USD")));
+
+    DomainException exception =
+        assertThrows(
+            DomainException.class,
+            () ->
+                new Transaction(
+                    TransactionId.random(),
+                    AccountId.random(),
+                    LocalDate.now(),
+                    TransactionDirection.OUTFLOW,
+                    new Money(new BigDecimal("200.00"), Currency.getInstance("USD")),
+                    "Buy shares",
+                    Instant.now(),
+                    trade));
+
+    assertEquals(TRANSACTION_TRADE_AMOUNT_MISMATCH, exception.code());
   }
 }

--- a/backend/postgres/src/main/java/com/mindfulfinance/postgres/PostgresTransactionRepository.java
+++ b/backend/postgres/src/main/java/com/mindfulfinance/postgres/PostgresTransactionRepository.java
@@ -6,6 +6,7 @@ import com.mindfulfinance.domain.money.Money;
 import com.mindfulfinance.domain.transaction.Transaction;
 import com.mindfulfinance.domain.transaction.TransactionDirection;
 import com.mindfulfinance.domain.transaction.TransactionId;
+import com.mindfulfinance.domain.transaction.TransactionTrade;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Currency;
@@ -24,7 +25,13 @@ public final class PostgresTransactionRepository implements TransactionRepositor
               TransactionDirection.valueOf(rs.getString("direction")),
               new Money(rs.getBigDecimal("amount"), Currency.getInstance(rs.getString("currency"))),
               rs.getString("memo"),
-              rs.getTimestamp("created_at").toInstant());
+              rs.getTimestamp("created_at").toInstant(),
+              toTrade(
+                  rs.getString("instrument_symbol"),
+                  rs.getBigDecimal("quantity"),
+                  rs.getBigDecimal("unit_price"),
+                  rs.getBigDecimal("fee_amount"),
+                  Currency.getInstance(rs.getString("currency"))));
 
   private final JdbcTemplate jdbcTemplate;
 
@@ -36,7 +43,8 @@ public final class PostgresTransactionRepository implements TransactionRepositor
   public List<Transaction> findByAccountId(AccountId accountId) {
     return jdbcTemplate.query(
         """
-                SELECT id, account_id, occurred_on, direction, amount, currency, memo, created_at
+                SELECT id, account_id, occurred_on, direction, amount, currency, memo, created_at,
+                       instrument_symbol, quantity, unit_price, fee_amount
                 FROM transactions
                 WHERE account_id = ?
                 ORDER BY occurred_on, created_at, id
@@ -57,8 +65,12 @@ public final class PostgresTransactionRepository implements TransactionRepositor
                     amount,
                     currency,
                     memo,
-                    created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    created_at,
+                    instrument_symbol,
+                    quantity,
+                    unit_price,
+                    fee_amount
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
         transaction.id().value(),
         transaction.accountId().value(),
@@ -67,7 +79,11 @@ public final class PostgresTransactionRepository implements TransactionRepositor
         transaction.amount().amount(),
         transaction.amount().currency().getCurrencyCode(),
         transaction.memo(),
-        Timestamp.from(transaction.createdAt()));
+        Timestamp.from(transaction.createdAt()),
+        transaction.trade() == null ? null : transaction.trade().instrumentSymbol(),
+        transaction.trade() == null ? null : transaction.trade().quantity(),
+        transaction.trade() == null ? null : transaction.trade().unitPrice().amount(),
+        transaction.trade() == null ? null : transaction.trade().feeAmount().amount());
   }
 
   @Override
@@ -76,13 +92,18 @@ public final class PostgresTransactionRepository implements TransactionRepositor
         jdbcTemplate.update(
             """
                 UPDATE transactions
-                SET occurred_on = ?, direction = ?, amount = ?, memo = ?
+                SET occurred_on = ?, direction = ?, amount = ?, memo = ?, instrument_symbol = ?,
+                    quantity = ?, unit_price = ?, fee_amount = ?
                 WHERE id = ? AND account_id = ?
                 """,
             Date.valueOf(transaction.occurredOn()),
             transaction.direction().name(),
             transaction.amount().amount(),
             transaction.memo(),
+            transaction.trade() == null ? null : transaction.trade().instrumentSymbol(),
+            transaction.trade() == null ? null : transaction.trade().quantity(),
+            transaction.trade() == null ? null : transaction.trade().unitPrice().amount(),
+            transaction.trade() == null ? null : transaction.trade().feeAmount().amount(),
             transaction.id().value(),
             transaction.accountId().value());
 
@@ -101,5 +122,25 @@ public final class PostgresTransactionRepository implements TransactionRepositor
             transactionId.value(),
             accountId.value())
         == 1;
+  }
+
+  private static TransactionTrade toTrade(
+      String instrumentSymbol,
+      java.math.BigDecimal quantity,
+      java.math.BigDecimal unitPrice,
+      java.math.BigDecimal feeAmount,
+      Currency currency) {
+    return Transaction.trade(
+        instrumentSymbol,
+        quantity,
+        toMoney(unitPrice, currency),
+        toMoney(feeAmount, currency));
+  }
+
+  private static Money toMoney(java.math.BigDecimal amount, Currency currency) {
+    if (amount == null || currency == null) {
+      return null;
+    }
+    return new Money(amount, currency);
   }
 }

--- a/backend/postgres/src/main/resources/db/migration/V11__investment_trade_transaction_fields.sql
+++ b/backend/postgres/src/main/resources/db/migration/V11__investment_trade_transaction_fields.sql
@@ -1,0 +1,25 @@
+ALTER TABLE transactions
+ADD COLUMN instrument_symbol TEXT,
+ADD COLUMN quantity NUMERIC,
+ADD COLUMN unit_price NUMERIC,
+ADD COLUMN fee_amount NUMERIC;
+
+ALTER TABLE transactions
+ADD CONSTRAINT transactions_trade_details_valid CHECK (
+    (
+        instrument_symbol IS NULL
+        AND quantity IS NULL
+        AND unit_price IS NULL
+        AND fee_amount IS NULL
+    )
+    OR (
+        instrument_symbol IS NOT NULL
+        AND char_length(trim(instrument_symbol)) > 0
+        AND quantity IS NOT NULL
+        AND quantity > 0
+        AND unit_price IS NOT NULL
+        AND unit_price > 0
+        AND fee_amount IS NOT NULL
+        AND fee_amount >= 0
+    )
+);

--- a/backend/postgres/src/test/java/com/mindfulfinance/postgres/MigrationSmokeTest.java
+++ b/backend/postgres/src/test/java/com/mindfulfinance/postgres/MigrationSmokeTest.java
@@ -34,7 +34,7 @@ class MigrationSmokeTest {
     flyway.clean();
     var result = flyway.migrate();
 
-    assertEquals(10, result.migrationsExecuted);
+    assertEquals(11, result.migrationsExecuted);
 
     try (var connection =
         DriverManager.getConnection(
@@ -63,12 +63,19 @@ class MigrationSmokeTest {
               "amount",
               "currency",
               "memo",
-              "created_at");
+              "created_at",
+              "instrument_symbol",
+              "quantity",
+              "unit_price",
+              "fee_amount");
 
       assertThat(loadColumnTypes(connection, "transactions"))
           .containsEntry("account_id", "uuid")
           .containsEntry("occurred_on", "date")
           .containsEntry("amount", "numeric")
+          .containsEntry("quantity", "numeric")
+          .containsEntry("unit_price", "numeric")
+          .containsEntry("fee_amount", "numeric")
           .containsEntry("created_at", "timestamp with time zone");
 
       assertThat(loadColumnTypes(connection, "personal_finance_cards"))

--- a/docs/product/05-developer-local-workflow.md
+++ b/docs/product/05-developer-local-workflow.md
@@ -37,15 +37,21 @@
 Проверка локального runtime smoke:
 
 1. `make dev`
-2. `curl http://localhost:8080/health` (ожидаемый ответ: `{"status":"ok"}`)
-3. открыть `http://localhost:5173`
+2. `curl http://localhost:${MINDFUL_FINANCE_API_PORT:-8080}/health` (ожидаемый ответ: `{"status":"ok"}`)
+3. открыть `http://localhost:${MINDFUL_FINANCE_FRONTEND_PORT:-5173}`
 4. `make down`
+
+Перед реальным запуском допускается безопасный dry-run orchestration через `make -n dev`.
 
 Backend-only smoke для разработки с сохранением тех же данных:
 
 1. `make backend-dev`
-2. `curl http://localhost:8080/health` (ожидаемый ответ: `{"status":"ok"}`)
+2. `curl http://localhost:${MINDFUL_FINANCE_API_PORT:-8080}/health` (ожидаемый ответ: `{"status":"ok"}`)
 3. остановить процесс через `Ctrl+C`
+
+Для backend-only пути безопасный dry-run выполняется через `make -n backend-dev`.
+
+Если `8080` или `5173` заняты, локальный runtime должен запускаться через переопределение `MINDFUL_FINANCE_API_PORT` и/или `MINDFUL_FINANCE_FRONTEND_PORT`, а не через правку кода.
 
 Локальный PostgreSQL хранит данные в persistent Docker volume и должен переживать `make down`. Если нужен чистый старт базы, он выполняется явно через `docker compose -f backend/docker-compose.yml down -v`.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -260,11 +260,7 @@ function App() {
   }, [activeView, accountsReloadTick])
 
   useEffect(() => {
-    if (
-      activeView !== 'accounts' ||
-      !selectedAccountId ||
-      !accounts.some((account) => account.id === selectedAccountId)
-    ) {
+    if (activeView !== 'accounts') {
       return
     }
 
@@ -275,19 +271,13 @@ function App() {
       setTransactionsErrorMessage(null)
 
       try {
-        const rows = await apiClient.listAccountTransactions(
-          selectedAccountId,
-          controller.signal,
-        )
+        const rows = await apiClient.listInvestmentTransactions(controller.signal)
 
         if (controller.signal.aborted) {
           return
         }
 
-        const sortedRows = [...rows].sort((left, right) =>
-          right.occurredOn.localeCompare(left.occurredOn),
-        )
-        setTransactions(sortedRows)
+        setTransactions(rows)
         setTransactionsStatus('ready')
         setCreateTransactionStatus('idle')
         setCreateTransactionErrorMessage(null)
@@ -306,7 +296,7 @@ function App() {
     return () => {
       controller.abort()
     }
-  }, [activeView, accounts, selectedAccountId, transactionsReloadTick])
+  }, [activeView, transactionsReloadTick])
 
   useEffect(() => {
     if (activeView !== 'personal-finance') {
@@ -470,6 +460,16 @@ function App() {
     })
   }, [transactions, directionFilter, memoFilter])
 
+  const selectedAccountTransactionsCount = useMemo(() => {
+    if (!selectedAccountId) {
+      return 0
+    }
+
+    return transactions.filter(
+      (transaction) => transaction.accountId === selectedAccountId,
+    ).length
+  }, [transactions, selectedAccountId])
+
   const headerContextLabel =
     activeView === 'personal-finance'
       ? activePersonalFinanceTab === 'settings'
@@ -483,20 +483,10 @@ function App() {
 
   const handleAccountSelect = (accountId: string): void => {
     if (accountId === selectedAccountId) {
-      setTransactionsReloadTick((tick) => tick + 1)
       return
     }
 
     setSelectedAccountId(accountId)
-    setDirectionFilter('ALL')
-    setMemoFilter('')
-    setTransactions([])
-    setTransactionsErrorMessage(null)
-    setCreateTransactionStatus('idle')
-    setCreateTransactionErrorMessage(null)
-    setCsvImportStatus('idle')
-    setCsvImportErrorMessage(null)
-    setCsvImportResult(null)
   }
 
   const handleCreateAccount = async (
@@ -525,6 +515,7 @@ function App() {
   ): Promise<void> => {
     await apiClient.updateAccount(accountId, request)
     setAccountsReloadTick((tick) => tick + 1)
+    setTransactionsReloadTick((tick) => tick + 1)
   }
 
   const handleDeleteAccount = async (accountId: string): Promise<void> => {
@@ -532,16 +523,9 @@ function App() {
 
     if (selectedAccountId === accountId) {
       setSelectedAccountId(null)
-      setTransactions([])
-      setTransactionsStatus('idle')
-      setTransactionsErrorMessage(null)
-      setCreateTransactionStatus('idle')
-      setCreateTransactionErrorMessage(null)
       setCsvImportStatus('idle')
       setCsvImportErrorMessage(null)
       setCsvImportResult(null)
-      setDirectionFilter('ALL')
-      setMemoFilter('')
     }
 
     setAccounts((current) =>
@@ -844,6 +828,7 @@ function App() {
           transactionsErrorMessage={transactionsErrorMessage}
           filteredTransactions={filteredTransactions}
           totalTransactionsCount={transactions.length}
+          selectedAccountTransactionsCount={selectedAccountTransactionsCount}
           directionFilter={directionFilter}
           memoFilter={memoFilter}
           onDirectionFilterChange={setDirectionFilter}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { createHttpClient, type HttpClientConfig } from './http'
+import { decodeTransactionDtoList } from './transaction-decoder'
 import type {
   AccountDto,
   CreateAccountRequest,
@@ -10,6 +11,7 @@ import type {
   CreateTransactionResponse,
   CurrencyTotalsDto,
   ImportTransactionsCsvResponse,
+  InstrumentOptionDto,
   IsoDate,
   MoneyDto,
   PersonalFinanceCardDto,
@@ -61,6 +63,12 @@ export interface ApiClient {
     accountId: string,
     signal?: AbortSignal,
   ): Promise<TransactionDto[]>
+  listInvestmentTransactions(signal?: AbortSignal): Promise<TransactionDto[]>
+  searchAccountInstruments(
+    accountId: string,
+    query: string,
+    signal?: AbortSignal,
+  ): Promise<InstrumentOptionDto[]>
   getAccountBalance(accountId: string, signal?: AbortSignal): Promise<MoneyDto>
   getNetWorth(signal?: AbortSignal): Promise<CurrencyTotalsDto>
   getMonthlyBurn(options?: {
@@ -223,9 +231,42 @@ export function createApiClient(config: HttpClientConfig = {}): ApiClient {
       accountId: string,
       signal?: AbortSignal,
     ): Promise<TransactionDto[]> {
-      return http.getJson<TransactionDto[]>(
-        `/accounts/${toEncodedAccountId(accountId)}/transactions`,
+      return http
+        .getJson<unknown>(
+          `/accounts/${toEncodedAccountId(accountId)}/transactions`,
+          {
+            signal,
+          },
+        )
+        .then((response) =>
+          decodeTransactionDtoList(
+            response,
+            `/accounts/${toEncodedAccountId(accountId)}/transactions`,
+          ),
+        )
+    },
+
+    listInvestmentTransactions(signal?: AbortSignal): Promise<TransactionDto[]> {
+      return http
+        .getJson<unknown>('/investment-transactions', {
+          signal,
+        })
+        .then((response) =>
+          decodeTransactionDtoList(response, '/investment-transactions'),
+        )
+    },
+
+    searchAccountInstruments(
+      accountId: string,
+      query: string,
+      signal?: AbortSignal,
+    ): Promise<InstrumentOptionDto[]> {
+      return http.getJson<InstrumentOptionDto[]>(
+        `/accounts/${toEncodedAccountId(accountId)}/instruments`,
         {
+          query: {
+            q: query.trim(),
+          },
           signal,
         },
       )

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -26,6 +26,8 @@ export type {
   ExpenseCategoryClassification,
   ExpenseLimitPeriod,
   ImportTransactionsCsvResponse,
+  InstrumentKind,
+  InstrumentOptionDto,
   IsoDate,
   MoneyDto,
   PersonalExpenseCategoryCode,

--- a/frontend/src/api/transaction-decoder.ts
+++ b/frontend/src/api/transaction-decoder.ts
@@ -1,0 +1,116 @@
+import type { DecimalAmount, TransactionDirection, TransactionDto } from './types'
+
+export class ApiDecodeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ApiDecodeError'
+  }
+}
+
+export function decodeTransactionDtoList(
+  input: unknown,
+  source: string,
+): TransactionDto[] {
+  if (!Array.isArray(input)) {
+    throw new ApiDecodeError(`${source} must return an array of transactions`)
+  }
+
+  return input.map((value, index) =>
+    decodeTransactionDto(value, `${source}[${index}]`),
+  )
+}
+
+function decodeTransactionDto(value: unknown, path: string): TransactionDto {
+  const object = requireRecord(value, path)
+
+  return {
+    id: requireString(object, 'id', path),
+    accountId: requireString(object, 'accountId', path),
+    accountName: requireString(object, 'accountName', path),
+    occurredOn: requireString(object, 'occurredOn', path),
+    direction: requireDirection(object.direction, `${path}.direction`),
+    amount: requireDecimalAmount(object.amount, `${path}.amount`),
+    currency: requireString(object, 'currency', path),
+    memo: requireNullableString(object, 'memo', path),
+    instrumentSymbol: requireNullableString(object, 'instrumentSymbol', path),
+    quantity: requireNullableDecimalAmount(object.quantity, `${path}.quantity`),
+    unitPrice: requireNullableDecimalAmount(object.unitPrice, `${path}.unitPrice`),
+    feeAmount: requireNullableDecimalAmount(object.feeAmount, `${path}.feeAmount`),
+  }
+}
+
+function requireRecord(
+  value: unknown,
+  path: string,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ApiDecodeError(`${path} must be an object`)
+  }
+
+  return value as Record<string, unknown>
+}
+
+function requireString(
+  object: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  const value = object[key]
+  if (typeof value !== 'string') {
+    throw new ApiDecodeError(`${path}.${key} must be a string`)
+  }
+
+  return value
+}
+
+function requireNullableString(
+  object: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | null {
+  const value = object[key]
+  if (value === null) {
+    return null
+  }
+  if (typeof value !== 'string') {
+    throw new ApiDecodeError(`${path}.${key} must be a string or null`)
+  }
+
+  return value
+}
+
+function requireDirection(
+  value: unknown,
+  path: string,
+): TransactionDirection {
+  if (value === 'INFLOW' || value === 'OUTFLOW') {
+    return value
+  }
+
+  throw new ApiDecodeError(`${path} must be INFLOW or OUTFLOW`)
+}
+
+function requireDecimalAmount(
+  value: unknown,
+  path: string,
+): DecimalAmount {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value)
+  }
+
+  throw new ApiDecodeError(`${path} must be a decimal string or number`)
+}
+
+function requireNullableDecimalAmount(
+  value: unknown,
+  path: string,
+): DecimalAmount | null {
+  if (value === null) {
+    return null
+  }
+
+  return requireDecimalAmount(value, path)
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -32,15 +32,23 @@ export type TransactionDirection = 'INFLOW' | 'OUTFLOW'
 export interface CreateTransactionRequest {
   occurredOn: IsoDate
   direction: TransactionDirection
-  amount: DecimalAmount
+  amount?: DecimalAmount
   memo: string
+  instrumentSymbol?: string
+  quantity?: DecimalAmount
+  unitPrice?: DecimalAmount
+  feeAmount?: DecimalAmount
 }
 
 export interface UpdateTransactionRequest {
   occurredOn: IsoDate
   direction: TransactionDirection
-  amount: DecimalAmount
+  amount?: DecimalAmount
   memo: string
+  instrumentSymbol?: string
+  quantity?: DecimalAmount
+  unitPrice?: DecimalAmount
+  feeAmount?: DecimalAmount
 }
 
 export interface CreateTransactionResponse {
@@ -55,11 +63,27 @@ export interface ImportTransactionsCsvResponse {
 
 export interface TransactionDto {
   id: string
+  accountId: string
+  accountName: string
   occurredOn: IsoDate
   direction: TransactionDirection
   amount: DecimalAmount
   currency: CurrencyCode
   memo: string | null
+  instrumentSymbol: string | null
+  quantity: DecimalAmount | null
+  unitPrice: DecimalAmount | null
+  feeAmount: DecimalAmount | null
+}
+
+export type InstrumentKind = 'SHARE' | 'FUND' | 'BOND'
+
+export interface InstrumentOptionDto {
+  symbol: string
+  shortName: string | null
+  name: string | null
+  isin: string | null
+  kind: InstrumentKind
 }
 
 export interface MoneyDto {

--- a/frontend/src/features/investments/InstrumentSearchField.tsx
+++ b/frontend/src/features/investments/InstrumentSearchField.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import {
+  ApiClientError,
+  apiClient,
+  type InstrumentOptionDto,
+} from '../../api'
+import {
+  isMoexTradeAccountType,
+  toAccountTypeLabel,
+  toInstrumentKindLabel,
+} from './formatting'
+import { normalizeInstrumentSymbol } from './transactionTrade'
+import type { AccountWithBalance } from './types'
+
+type SearchStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+interface InstrumentSearchFieldProps {
+  account: AccountWithBalance | null
+  value: string
+  onChange: (symbol: string) => void
+}
+
+export function InstrumentSearchField({
+  account,
+  value,
+  onChange,
+}: InstrumentSearchFieldProps) {
+  const normalizedValue = normalizeInstrumentSymbol(value)
+  const [query, setQuery] = useState<string>(normalizedValue)
+  const [options, setOptions] = useState<InstrumentOptionDto[]>([])
+  const [status, setStatus] = useState<SearchStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const listboxId = useId()
+  const blurTimeoutRef = useRef<number | null>(null)
+  const skipNextValueSyncRef = useRef<boolean>(false)
+
+  const supportsMoexSearch =
+    account !== null && isMoexTradeAccountType(account.type)
+  const exactMatchOption = useMemo(
+    () => options.find((option) => option.symbol === normalizedValue) ?? null,
+    [options, normalizedValue],
+  )
+  const showUnresolvedValue =
+    supportsMoexSearch &&
+    normalizedValue.length > 0 &&
+    query === normalizedValue &&
+    status === 'ready' &&
+    exactMatchOption === null
+
+  useEffect(() => {
+    if (skipNextValueSyncRef.current) {
+      skipNextValueSyncRef.current = false
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setQuery(normalizedValue)
+      setOptions([])
+      setStatus('idle')
+      setErrorMessage(null)
+      setIsOpen(false)
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [normalizedValue])
+
+  useEffect(() => {
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current)
+      blurTimeoutRef.current = null
+    }
+
+    if (!supportsMoexSearch) {
+      return
+    }
+
+    const trimmedQuery = query.trim()
+    if (trimmedQuery.length < 2) {
+      return
+    }
+
+    const controller = new AbortController()
+    const timeoutId = window.setTimeout(() => {
+      setStatus('loading')
+      setIsOpen(true)
+
+      void apiClient
+        .searchAccountInstruments(account.id, trimmedQuery, controller.signal)
+        .then((rows) => {
+          if (controller.signal.aborted) {
+            return
+          }
+
+          setOptions(rows)
+          setStatus('ready')
+          setErrorMessage(null)
+        })
+        .catch((error: unknown) => {
+          if (
+            controller.signal.aborted ||
+            (error instanceof DOMException && error.name === 'AbortError')
+          ) {
+            return
+          }
+
+          setOptions([])
+          setStatus('error')
+          setErrorMessage(toInstrumentSearchErrorMessage(error))
+        })
+    }, 250)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+      controller.abort()
+    }
+  }, [account?.id, query, supportsMoexSearch])
+
+  const handleInputChange = (nextValue: string): void => {
+    const normalizedQuery = normalizeInstrumentSymbol(nextValue)
+    setQuery(normalizedQuery)
+    setOptions([])
+    setStatus('idle')
+    setErrorMessage(null)
+    setIsOpen(normalizedQuery.trim().length >= 2)
+
+    if (normalizedQuery !== normalizedValue) {
+      skipNextValueSyncRef.current = true
+      onChange('')
+    }
+  }
+
+  const handleSelectOption = (option: InstrumentOptionDto): void => {
+    setQuery(option.symbol)
+    setIsOpen(false)
+    onChange(option.symbol)
+  }
+
+  const handleInputBlur = (): void => {
+    blurTimeoutRef.current = window.setTimeout(() => {
+      setIsOpen(false)
+      blurTimeoutRef.current = null
+    }, 120)
+  }
+
+  const handleInputFocus = (): void => {
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current)
+      blurTimeoutRef.current = null
+    }
+
+    if (supportsMoexSearch && query.trim().length >= 2) {
+      setIsOpen(true)
+    }
+  }
+
+  if (account === null) {
+    return (
+      <div className="mt-1 space-y-2">
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-500">
+          Сначала выберите счет
+        </div>
+      </div>
+    )
+  }
+
+  if (!supportsMoexSearch) {
+    return (
+      <div className="mt-1 space-y-2">
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+          {normalizedValue.length > 0 ? normalizedValue : 'Выбор инструмента недоступен'}
+        </div>
+        <p className="text-[11px] text-slate-500">
+          Для счета типа {toAccountTypeLabel(account.type)} подбор инструментов с
+          Московской биржи не поддерживается.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-1">
+      <div className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => handleInputChange(event.target.value)}
+          onBlur={handleInputBlur}
+          onFocus={handleInputFocus}
+          placeholder="Начните вводить символ"
+          autoComplete="off"
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? listboxId : undefined}
+          className="block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+        />
+
+        {isOpen ? (
+          <div
+            className="absolute z-20 mt-1 w-full rounded-md border border-slate-200 bg-white shadow-lg"
+            role="listbox"
+            id={listboxId}
+          >
+            {status === 'loading' ? (
+              <p className="px-3 py-2 text-xs text-slate-500">
+                Ищем инструменты на MOEX...
+              </p>
+            ) : null}
+
+            {status === 'error' && errorMessage ? (
+              <p className="px-3 py-2 text-xs text-amber-700">{errorMessage}</p>
+            ) : null}
+
+            {status === 'ready' && options.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-slate-500">
+                Ничего не найдено на Московской бирже.
+              </p>
+            ) : null}
+
+            {options.length > 0 ? (
+              <ul className="max-h-64 overflow-y-auto py-1">
+                {options.map((option) => {
+                  const isSelected = option.symbol === normalizedValue
+                  return (
+                    <li key={option.symbol}>
+                      <button
+                        type="button"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => handleSelectOption(option)}
+                        className={`flex w-full items-start justify-between gap-3 px-3 py-2 text-left ${
+                          isSelected
+                            ? 'bg-slate-100 text-slate-900'
+                            : 'text-slate-700 hover:bg-slate-50'
+                        }`}
+                      >
+                        <span className="min-w-0">
+                          <span className="block text-sm font-medium">
+                            {option.symbol}
+                          </span>
+                          <span className="block truncate text-xs text-slate-500">
+                            {toOptionSecondaryText(option)}
+                          </span>
+                        </span>
+                        <span className="rounded-full border border-slate-200 px-2 py-0.5 text-[10px] uppercase tracking-wide text-slate-500">
+                          {toInstrumentKindLabel(option.kind)}
+                        </span>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-2 space-y-1">
+        {query.trim().length < 2 ? (
+          <p className="text-[11px] text-slate-500">
+            Введите минимум 2 символа для поиска по MOEX.
+          </p>
+        ) : null}
+
+        {showUnresolvedValue ? (
+          <p className="text-[11px] text-slate-500">
+            Сохранен символ {normalizedValue}, но сейчас его нет в выдаче MOEX
+            для этого типа счета. Вы можете оставить его как есть или выбрать
+            новый инструмент из списка.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function toOptionSecondaryText(option: InstrumentOptionDto): string {
+  const parts = [option.shortName ?? option.name, option.isin]
+    .filter((value): value is string => value !== null && value.length > 0)
+    .slice(0, 2)
+
+  return parts.join(' · ')
+}
+
+function toInstrumentSearchErrorMessage(error: unknown): string {
+  if (error instanceof ApiClientError) {
+    return error.message
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return 'Не удалось загрузить инструменты.'
+}

--- a/frontend/src/features/investments/InvestmentTransactionsTab.tsx
+++ b/frontend/src/features/investments/InvestmentTransactionsTab.tsx
@@ -1,25 +1,29 @@
-import { type FormEvent } from 'react'
-import type { TransactionDirection, TransactionDto } from '../../api'
+import type { TransactionDto } from '../../api'
 import { formatMoneyInput } from '../../money-input'
+import { InstrumentSearchField } from './InstrumentSearchField'
 import {
+  formatAmount,
   formatIsoDateRu,
   formatSignedAmount,
+  isMoexTradeAccountType,
   toDirectionLabel,
-  toDirectionSelectLabel,
   toTransactionMemoDisplay,
 } from './formatting'
+import {
+  formatDecimalInput,
+  type TransactionTradeDraft,
+  type TransactionTradeEvaluation,
+} from './transactionTrade'
 import type {
   AccountWithBalance,
   CreateTransactionStatus,
   LoadStatus,
   TransactionDirectionFilter,
 } from './types'
-import { InvestmentAccountSelectorList, StatusCard } from './ui'
+import { StatusCard } from './ui'
 
 interface InvestmentTransactionsTabProps {
   accounts: AccountWithBalance[]
-  selectedAccountId: string | null
-  selectedAccount: AccountWithBalance | null
   transactionsStatus: LoadStatus
   transactionsErrorMessage: string | null
   filteredTransactions: TransactionDto[]
@@ -28,32 +32,23 @@ interface InvestmentTransactionsTabProps {
   memoFilter: string
   onDirectionFilterChange: (value: TransactionDirectionFilter) => void
   onMemoFilterChange: (value: string) => void
-  onSelectAccount: (accountId: string) => void
   createTransactionStatus: CreateTransactionStatus
   createTransactionErrorMessage: string | null
-  newTransactionDate: string
-  newTransactionDirection: TransactionDirection
-  newTransactionAmount: string
-  newTransactionMemo: string
-  onNewTransactionDateChange: (value: string) => void
-  onNewTransactionDirectionChange: (value: TransactionDirection) => void
-  onNewTransactionAmountChange: (value: string) => void
-  onNewTransactionMemoChange: (value: string) => void
-  isTransactionAmountValid: boolean
+  newTransactionDraft: TransactionTradeDraft
+  newTransactionEvaluation: TransactionTradeEvaluation
+  newTransactionAccount: AccountWithBalance | null
+  onNewTransactionDraftChange: (draft: TransactionTradeDraft) => void
+  onNewTransactionAccountChange: (accountId: string) => void
   canCreateTransaction: boolean
   onCreateTransactionSubmit: (
-    event: FormEvent<HTMLFormElement>,
+    options?: { resetAfterSave: boolean },
   ) => Promise<void>
+  onResetNewTransaction: () => void
   activeEditingTransactionId: string | null
-  editingTransactionDate: string
-  editingTransactionDirection: TransactionDirection
-  editingTransactionAmount: string
-  editingTransactionMemo: string
-  onEditingTransactionDateChange: (value: string) => void
-  onEditingTransactionDirectionChange: (value: TransactionDirection) => void
-  onEditingTransactionAmountChange: (value: string) => void
-  onEditingTransactionMemoChange: (value: string) => void
-  isEditingTransactionAmountValid: boolean
+  editingTransactionDraft: TransactionTradeDraft
+  editingTransactionEvaluation: TransactionTradeEvaluation
+  editingTransactionAccount: AccountWithBalance | null
+  onEditingTransactionDraftChange: (draft: TransactionTradeDraft) => void
   canUpdateTransaction: boolean
   updateTransactionStatus: CreateTransactionStatus
   updateTransactionErrorMessage: string | null
@@ -61,9 +56,7 @@ interface InvestmentTransactionsTabProps {
   deleteTransactionErrorMessage: string | null
   isDeleteTransactionSubmitting: boolean
   onStartEditingTransaction: (transaction: TransactionDto) => void
-  onUpdateTransactionSubmit: (
-    event: FormEvent<HTMLFormElement>,
-  ) => Promise<void>
+  onUpdateTransactionSubmit: () => Promise<void>
   onCancelEditingTransaction: () => void
   onDeleteTransaction: (transaction: TransactionDto) => Promise<void>
   onRetryTransactions: () => void
@@ -72,8 +65,6 @@ interface InvestmentTransactionsTabProps {
 
 export function InvestmentTransactionsTab({
   accounts,
-  selectedAccountId,
-  selectedAccount,
   transactionsStatus,
   transactionsErrorMessage,
   filteredTransactions,
@@ -82,30 +73,21 @@ export function InvestmentTransactionsTab({
   memoFilter,
   onDirectionFilterChange,
   onMemoFilterChange,
-  onSelectAccount,
   createTransactionStatus,
   createTransactionErrorMessage,
-  newTransactionDate,
-  newTransactionDirection,
-  newTransactionAmount,
-  newTransactionMemo,
-  onNewTransactionDateChange,
-  onNewTransactionDirectionChange,
-  onNewTransactionAmountChange,
-  onNewTransactionMemoChange,
-  isTransactionAmountValid,
+  newTransactionDraft,
+  newTransactionEvaluation,
+  newTransactionAccount,
+  onNewTransactionDraftChange,
+  onNewTransactionAccountChange,
   canCreateTransaction,
   onCreateTransactionSubmit,
+  onResetNewTransaction,
   activeEditingTransactionId,
-  editingTransactionDate,
-  editingTransactionDirection,
-  editingTransactionAmount,
-  editingTransactionMemo,
-  onEditingTransactionDateChange,
-  onEditingTransactionDirectionChange,
-  onEditingTransactionAmountChange,
-  onEditingTransactionMemoChange,
-  isEditingTransactionAmountValid,
+  editingTransactionDraft,
+  editingTransactionEvaluation,
+  editingTransactionAccount,
+  onEditingTransactionDraftChange,
   canUpdateTransaction,
   updateTransactionStatus,
   updateTransactionErrorMessage,
@@ -137,417 +119,594 @@ export function InvestmentTransactionsTab({
     )
   }
 
+  const supportedTransactionAccounts = accounts.filter((account) =>
+    isMoexTradeAccountType(account.type),
+  )
+
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.3fr)]">
-      <article className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-        <h2 className="text-sm font-semibold text-slate-900">
-          Инвестиционные счета
-        </h2>
-        <p className="mt-1 text-xs text-slate-500">
-          Выберите счет, чтобы посмотреть и изменить его транзакции.
-        </p>
+    <article className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-900">
+            Все инвестиционные транзакции
+          </h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Глобальный список покупок и продаж по всем инвестиционным счетам.
+          </p>
+        </div>
 
-        <InvestmentAccountSelectorList
-          accounts={accounts}
-          selectedAccountId={selectedAccountId}
-          onSelectAccount={onSelectAccount}
-          emptyMessage="Пока нет счетов."
-        />
-      </article>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800"
+        >
+          Настроить счета
+        </button>
+      </div>
 
-      <article className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-        {!selectedAccount ? (
+      <TransactionTradeForm
+        title="Добавить транзакцию"
+        accounts={supportedTransactionAccounts}
+        selectedAccountId={newTransactionDraft.accountId}
+        onSelectedAccountIdChange={onNewTransactionAccountChange}
+        currency={newTransactionAccount?.balance.currency ?? '—'}
+        draft={newTransactionDraft}
+        evaluation={newTransactionEvaluation}
+        onDraftChange={onNewTransactionDraftChange}
+        canSubmit={canCreateTransaction}
+        submitLabel={
+          createTransactionStatus === 'submitting' ? 'Сохраняем...' : 'Сохранить'
+        }
+        secondarySubmitLabel="Сохранить и добавить еще"
+        onSubmit={() => {
+          void onCreateTransactionSubmit()
+        }}
+        onSecondarySubmit={() => {
+          void onCreateTransactionSubmit({ resetAfterSave: true })
+        }}
+        onCancel={onResetNewTransaction}
+        errorMessage={
+          createTransactionStatus === 'error'
+            ? createTransactionErrorMessage
+            : null
+        }
+        className="mt-4"
+      />
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <label className="text-xs text-slate-600">
+          Направление
+          <select
+            value={directionFilter}
+            onChange={(event) =>
+              onDirectionFilterChange(
+                event.target.value as TransactionDirectionFilter,
+              )
+            }
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          >
+            <option value="ALL">Все</option>
+            <option value="INFLOW">Продажи</option>
+            <option value="OUTFLOW">Покупки</option>
+          </select>
+        </label>
+
+        <label className="text-xs text-slate-600">
+          Фильтр по заметкам
+          <input
+            type="text"
+            value={memoFilter}
+            onChange={(event) => onMemoFilterChange(event.target.value)}
+            placeholder="Поиск по заметкам"
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          />
+        </label>
+      </div>
+
+      <div className="mt-4">
+        {transactionsStatus === 'loading' || transactionsStatus === 'idle' ? (
+          <StatusCard tone="neutral" message="Загружаем транзакции..." />
+        ) : null}
+
+        {transactionsStatus === 'error' ? (
+          <StatusCard
+            tone="warning"
+            message={
+              transactionsErrorMessage ?? 'Не удалось загрузить транзакции.'
+            }
+            actionLabel="Повторить"
+            onAction={onRetryTransactions}
+          />
+        ) : null}
+
+        {transactionsStatus === 'ready' && totalTransactionsCount === 0 ? (
           <StatusCard
             tone="neutral"
-            message="Выберите счет, чтобы посмотреть транзакции."
+            message="Пока нет инвестиционных транзакций."
           />
-        ) : (
-          <>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div>
-                <h2 className="text-sm font-semibold text-slate-900">
-                  {selectedAccount.name}
-                </h2>
-                <p className="mt-1 text-xs uppercase tracking-wide text-slate-500">
-                  Транзакции · {selectedAccount.balance.currency}
-                </p>
-              </div>
+        ) : null}
 
-              <button
-                type="button"
-                onClick={onOpenSettings}
-                className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800"
-              >
-                Настроить счет
-              </button>
-            </div>
+        {transactionsStatus === 'ready' &&
+        totalTransactionsCount > 0 &&
+        filteredTransactions.length === 0 ? (
+          <StatusCard
+            tone="neutral"
+            message="Нет транзакций, подходящих под фильтры."
+          />
+        ) : null}
 
-            <form
-              className="mt-4 rounded-lg border border-slate-200 bg-white p-3"
-              onSubmit={(event) => {
-                void onCreateTransactionSubmit(event)
-              }}
-            >
-              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                Добавить транзакцию
-              </p>
+        {transactionsStatus === 'ready' && filteredTransactions.length > 0 ? (
+          <ul className="space-y-2">
+            {filteredTransactions.map((transaction) => {
+              const isEditing = activeEditingTransactionId === transaction.id
+              const hasDeleteError =
+                deletingTransactionId === transaction.id &&
+                deleteTransactionErrorMessage !== null
+              const isDeletingThisTransaction =
+                deletingTransactionId === transaction.id &&
+                deleteTransactionErrorMessage === null
 
-              <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                <label className="text-xs text-slate-600">
-                  Дата
-                  <input
-                    type="date"
-                    value={newTransactionDate}
-                    onChange={(event) =>
-                      onNewTransactionDateChange(event.target.value)
-                    }
-                    className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                  />
-                </label>
-
-                <label className="text-xs text-slate-600">
-                  Направление
-                  <select
-                    value={newTransactionDirection}
-                    onChange={(event) =>
-                      onNewTransactionDirectionChange(
-                        event.target.value as TransactionDirection,
-                      )
-                    }
-                    className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                  >
-                    <option value="OUTFLOW">
-                      {toDirectionSelectLabel('OUTFLOW')}
-                    </option>
-                    <option value="INFLOW">
-                      {toDirectionSelectLabel('INFLOW')}
-                    </option>
-                  </select>
-                </label>
-              </div>
-
-              <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,0.6fr)_minmax(0,1fr)]">
-                <label className="text-xs text-slate-600">
-                  Сумма
-                  <input
-                    type="text"
-                    inputMode="decimal"
-                    value={newTransactionAmount}
-                    onChange={(event) =>
-                      onNewTransactionAmountChange(
-                        formatMoneyInput(event.target.value),
-                      )
-                    }
-                    placeholder="0,00"
-                    className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                  />
-                </label>
-
-                <label className="text-xs text-slate-600">
-                  Описание
-                  <input
-                    type="text"
-                    value={newTransactionMemo}
-                    onChange={(event) =>
-                      onNewTransactionMemoChange(event.target.value)
-                    }
-                    placeholder="Покупка фонда"
-                    className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                  />
-                </label>
-              </div>
-
-              {!isTransactionAmountValid &&
-              newTransactionAmount.trim().length > 0 ? (
-                <p className="mt-2 text-xs text-amber-700">
-                  Сумма должна быть положительной и содержать не более 2 знаков
-                  после запятой.
-                </p>
-              ) : null}
-
-              {createTransactionStatus === 'error' &&
-              createTransactionErrorMessage ? (
-                <p className="mt-2 text-xs text-amber-700">
-                  {createTransactionErrorMessage}
-                </p>
-              ) : null}
-
-              <button
-                type="submit"
-                disabled={!canCreateTransaction}
-                className="mt-3 rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {createTransactionStatus === 'submitting'
-                  ? 'Добавляем...'
-                  : 'Добавить транзакцию'}
-              </button>
-            </form>
-
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              <label className="text-xs text-slate-600">
-                Направление
-                <select
-                  value={directionFilter}
-                  onChange={(event) =>
-                    onDirectionFilterChange(
-                      event.target.value as TransactionDirectionFilter,
-                    )
-                  }
-                  className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+              return (
+                <li
+                  key={transaction.id}
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-3"
                 >
-                  <option value="ALL">Все</option>
-                  <option value="INFLOW">Доходы</option>
-                  <option value="OUTFLOW">Расходы</option>
-                </select>
-              </label>
-
-              <label className="text-xs text-slate-600">
-                Фильтр по описанию
-                <input
-                  type="text"
-                  value={memoFilter}
-                  onChange={(event) => onMemoFilterChange(event.target.value)}
-                  placeholder="Поиск по описанию"
-                  className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                />
-              </label>
-            </div>
-
-            <div className="mt-4">
-              {transactionsStatus === 'loading' ||
-              transactionsStatus === 'idle' ? (
-                <StatusCard tone="neutral" message="Загружаем транзакции..." />
-              ) : null}
-
-              {transactionsStatus === 'error' ? (
-                <StatusCard
-                  tone="warning"
-                  message={
-                    transactionsErrorMessage ??
-                    'Не удалось загрузить транзакции.'
-                  }
-                  actionLabel="Повторить"
-                  onAction={onRetryTransactions}
-                />
-              ) : null}
-
-              {transactionsStatus === 'ready' &&
-              totalTransactionsCount === 0 ? (
-                <StatusCard
-                  tone="neutral"
-                  message="Для этого счета пока нет транзакций."
-                />
-              ) : null}
-
-              {transactionsStatus === 'ready' &&
-              totalTransactionsCount > 0 &&
-              filteredTransactions.length === 0 ? (
-                <StatusCard
-                  tone="neutral"
-                  message="Нет транзакций, подходящих под фильтры."
-                />
-              ) : null}
-
-              {transactionsStatus === 'ready' &&
-              filteredTransactions.length > 0 ? (
-                <ul className="space-y-2">
-                  {filteredTransactions.map((transaction) => {
-                    const isEditing =
-                      activeEditingTransactionId === transaction.id
-                    const hasDeleteError =
-                      deletingTransactionId === transaction.id &&
-                      deleteTransactionErrorMessage !== null
-                    const isDeletingThisTransaction =
-                      deletingTransactionId === transaction.id &&
-                      deleteTransactionErrorMessage === null
-
-                    return (
-                      <li
-                        key={transaction.id}
-                        className="rounded-lg border border-slate-200 bg-white px-3 py-3"
-                      >
-                        {isEditing ? (
-                          <form
-                            onSubmit={(event) => {
-                              void onUpdateTransactionSubmit(event)
-                            }}
+                  {isEditing ? (
+                    <TransactionTradeForm
+                      title="Редактировать транзакцию"
+                      accounts={accounts}
+                      selectedAccountId={editingTransactionAccount?.id ?? null}
+                      currency={
+                        editingTransactionAccount?.balance.currency ??
+                        transaction.currency
+                      }
+                      draft={editingTransactionDraft}
+                      evaluation={editingTransactionEvaluation}
+                      onDraftChange={onEditingTransactionDraftChange}
+                      canSubmit={canUpdateTransaction}
+                      submitLabel={
+                        updateTransactionStatus === 'submitting'
+                          ? 'Сохраняем...'
+                          : 'Сохранить'
+                      }
+                      onSubmit={() => {
+                        void onUpdateTransactionSubmit()
+                      }}
+                      onCancel={onCancelEditingTransaction}
+                      errorMessage={
+                        updateTransactionStatus === 'error'
+                          ? updateTransactionErrorMessage
+                          : null
+                      }
+                    />
+                  ) : (
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-medium text-slate-900">
+                          {toTransactionTitle(transaction)}
+                        </p>
+                        <p className="mt-1 text-xs uppercase tracking-wide text-slate-500">
+                          {transaction.accountName}
+                        </p>
+                        <p className="mt-1 text-xs text-slate-500">
+                          {formatIsoDateRu(transaction.occurredOn)} ·{' '}
+                          {toDirectionLabel(transaction.direction)}
+                          {transaction.quantity && transaction.unitPrice ? (
+                            <>
+                              {' '}
+                              · {formatDecimalDisplay(transaction.quantity)} ×{' '}
+                              {formatAmount(transaction.unitPrice)}
+                            </>
+                          ) : null}
+                          {transaction.feeAmount ? (
+                            <> · Комиссия {formatAmount(transaction.feeAmount)}</>
+                          ) : null}
+                        </p>
+                        {transaction.memo ? (
+                          <p className="mt-2 text-xs text-slate-500">
+                            {toTransactionMemoDisplay(transaction.memo)}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="text-right">
+                        <p className="text-xs uppercase tracking-wide text-slate-500">
+                          {transaction.currency}
+                        </p>
+                        <p
+                          className={`mt-1 text-sm font-semibold ${
+                            transaction.direction === 'OUTFLOW'
+                              ? 'text-rose-700'
+                              : 'text-emerald-700'
+                          }`}
+                        >
+                          {formatSignedAmount(
+                            transaction.amount,
+                            transaction.direction,
+                          )}
+                        </p>
+                        <div className="mt-2 flex flex-wrap justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onStartEditingTransaction(transaction)}
+                            disabled={isDeleteTransactionSubmitting}
+                            className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 disabled:cursor-not-allowed disabled:opacity-50"
                           >
-                            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                              Редактировать транзакцию
-                            </p>
-
-                            <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                              <label className="text-xs text-slate-600">
-                                Дата
-                                <input
-                                  type="date"
-                                  value={editingTransactionDate}
-                                  onChange={(event) =>
-                                    onEditingTransactionDateChange(
-                                      event.target.value,
-                                    )
-                                  }
-                                  className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                                />
-                              </label>
-
-                              <label className="text-xs text-slate-600">
-                                Направление
-                                <select
-                                  value={editingTransactionDirection}
-                                  onChange={(event) =>
-                                    onEditingTransactionDirectionChange(
-                                      event.target
-                                        .value as TransactionDirection,
-                                    )
-                                  }
-                                  className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                                >
-                                  <option value="OUTFLOW">
-                                    {toDirectionSelectLabel('OUTFLOW')}
-                                  </option>
-                                  <option value="INFLOW">
-                                    {toDirectionSelectLabel('INFLOW')}
-                                  </option>
-                                </select>
-                              </label>
-                            </div>
-
-                            <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,0.6fr)_minmax(0,1fr)]">
-                              <label className="text-xs text-slate-600">
-                                Сумма
-                                <input
-                                  type="text"
-                                  inputMode="decimal"
-                                  value={editingTransactionAmount}
-                                  onChange={(event) =>
-                                    onEditingTransactionAmountChange(
-                                      formatMoneyInput(event.target.value),
-                                    )
-                                  }
-                                  placeholder="0,00"
-                                  className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                                />
-                              </label>
-
-                              <label className="text-xs text-slate-600">
-                                Описание
-                                <input
-                                  type="text"
-                                  value={editingTransactionMemo}
-                                  onChange={(event) =>
-                                    onEditingTransactionMemoChange(
-                                      event.target.value,
-                                    )
-                                  }
-                                  placeholder="Без описания"
-                                  className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
-                                />
-                              </label>
-                            </div>
-
-                            {!isEditingTransactionAmountValid &&
-                            editingTransactionAmount.trim().length > 0 ? (
-                              <p className="mt-2 text-xs text-amber-700">
-                                Сумма должна быть положительной и содержать не
-                                более 2 знаков после запятой.
-                              </p>
-                            ) : null}
-
-                            {updateTransactionStatus === 'error' &&
-                            updateTransactionErrorMessage ? (
-                              <p className="mt-2 text-xs text-amber-700">
-                                {updateTransactionErrorMessage}
-                              </p>
-                            ) : null}
-
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              <button
-                                type="submit"
-                                disabled={!canUpdateTransaction}
-                                className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
-                              >
-                                {updateTransactionStatus === 'submitting'
-                                  ? 'Сохраняем...'
-                                  : 'Сохранить'}
-                              </button>
-                              <button
-                                type="button"
-                                onClick={onCancelEditingTransaction}
-                                className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600"
-                              >
-                                Отмена
-                              </button>
-                            </div>
-                          </form>
-                        ) : (
-                          <div className="flex items-center justify-between gap-3">
-                            <div>
-                              <p className="text-sm font-medium text-slate-900">
-                                {toTransactionMemoDisplay(transaction.memo)}
-                              </p>
-                              <p className="mt-1 text-xs text-slate-500">
-                                {formatIsoDateRu(transaction.occurredOn)} ·{' '}
-                                {toDirectionLabel(transaction.direction)}
-                              </p>
-                            </div>
-                            <div className="text-right">
-                              <p className="text-xs uppercase tracking-wide text-slate-500">
-                                {transaction.currency}
-                              </p>
-                              <p
-                                className={`mt-1 text-sm font-semibold ${
-                                  transaction.direction === 'OUTFLOW'
-                                    ? 'text-rose-700'
-                                    : 'text-emerald-700'
-                                }`}
-                              >
-                                {formatSignedAmount(
-                                  transaction.amount,
-                                  transaction.direction,
-                                )}
-                              </p>
-                              <div className="mt-2 flex flex-wrap justify-end gap-2">
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    onStartEditingTransaction(transaction)
-                                  }
-                                  disabled={isDeleteTransactionSubmitting}
-                                  className="rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 disabled:cursor-not-allowed disabled:opacity-50"
-                                >
-                                  Редактировать
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    void onDeleteTransaction(transaction)
-                                  }}
-                                  disabled={isDeleteTransactionSubmitting}
-                                  className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-medium text-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
-                                >
-                                  {isDeletingThisTransaction
-                                    ? 'Удаляем...'
-                                    : 'Удалить'}
-                                </button>
-                              </div>
-                              {hasDeleteError ? (
-                                <p className="mt-2 text-xs text-amber-700">
-                                  {deleteTransactionErrorMessage}
-                                </p>
-                              ) : null}
-                            </div>
-                          </div>
-                        )}
-                      </li>
-                    )
-                  })}
-                </ul>
-              ) : null}
-            </div>
-          </>
-        )}
-      </article>
-    </div>
+                            Редактировать
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void onDeleteTransaction(transaction)
+                            }}
+                            disabled={isDeleteTransactionSubmitting}
+                            className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-medium text-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isDeletingThisTransaction ? 'Удаляем...' : 'Удалить'}
+                          </button>
+                        </div>
+                        {hasDeleteError ? (
+                          <p className="mt-2 text-xs text-amber-700">
+                            {deleteTransactionErrorMessage}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        ) : null}
+      </div>
+    </article>
   )
+}
+
+interface TransactionTradeFormProps {
+  title: string
+  accounts: AccountWithBalance[]
+  selectedAccountId: string | null
+  onSelectedAccountIdChange?: (accountId: string) => void
+  currency: string
+  draft: TransactionTradeDraft
+  evaluation: TransactionTradeEvaluation
+  onDraftChange: (draft: TransactionTradeDraft) => void
+  canSubmit: boolean
+  submitLabel: string
+  onSubmit: () => void
+  onCancel: () => void
+  onSecondarySubmit?: () => void
+  secondarySubmitLabel?: string
+  errorMessage: string | null
+  className?: string
+}
+
+function TransactionTradeForm({
+  title,
+  accounts,
+  selectedAccountId,
+  onSelectedAccountIdChange,
+  currency,
+  draft,
+  evaluation,
+  onDraftChange,
+  canSubmit,
+  submitLabel,
+  onSubmit,
+  onCancel,
+  onSecondarySubmit,
+  secondarySubmitLabel,
+  errorMessage,
+  className,
+}: TransactionTradeFormProps) {
+  const isCreateForm = onSelectedAccountIdChange !== undefined
+  const selectedAccount =
+    accounts.find((account) => account.id === selectedAccountId) ?? null
+  const patchDraft = (patch: Partial<TransactionTradeDraft>): void => {
+    onDraftChange({
+      ...draft,
+      ...patch,
+    })
+  }
+
+  const validationMessages = [
+    !evaluation.isInstrumentSymbolValid && draft.instrumentSymbol.trim().length > 0
+      ? 'Укажите непустой символ инструмента.'
+      : null,
+    !evaluation.isUnitPriceValid && draft.unitPrice.trim().length > 0
+      ? 'Цена должна быть положительной и содержать не более 2 знаков после точки.'
+      : null,
+    !evaluation.isQuantityValid && draft.quantity.trim().length > 0
+      ? 'Количество должно быть положительным и содержать не более 6 знаков после точки.'
+      : null,
+    !evaluation.isFeeAmountValid && draft.feeAmount.trim().length > 0
+      ? 'Комиссия не может быть отрицательной и должна содержать не более 2 знаков после точки.'
+      : null,
+    !evaluation.isTotalAmountValid &&
+    evaluation.isUnitPriceValid &&
+    evaluation.isQuantityValid &&
+    evaluation.isFeeAmountValid
+      ? 'Итог должен точно укладываться в валютную сумму с 2 знаками после точки.'
+      : null,
+  ].filter((message): message is string => message !== null)
+
+  if (isCreateForm && accounts.length === 0) {
+    return (
+      <section
+        className={`rounded-lg border border-slate-200 bg-white p-4 ${className ?? ''}`}
+      >
+        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+          {title}
+        </p>
+        <StatusCard
+          tone="neutral"
+          message="Для выбора инструмента с Московской биржи нужен брокерский счет или ИИС."
+        />
+      </section>
+    )
+  }
+
+  return (
+    <section
+      className={`rounded-lg border border-slate-200 bg-white p-4 ${className ?? ''}`}
+    >
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        {title}
+      </p>
+
+      <label className="mt-4 block text-xs text-slate-600">
+        Счет
+        {onSelectedAccountIdChange ? (
+          <select
+            value={selectedAccountId ?? ''}
+            onChange={(event) => onSelectedAccountIdChange(event.target.value)}
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          >
+            <option value="" disabled>
+              Выберите счет
+            </option>
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name} · {account.balance.currency}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <div className="mt-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+            {selectedAccount
+              ? `${selectedAccount.name} · ${selectedAccount.balance.currency}`
+              : 'Счет не найден'}
+          </div>
+        )}
+      </label>
+
+      <div className="mt-3">
+        <p className="text-xs text-slate-600">Направление</p>
+        <div className="mt-1 grid grid-cols-2 gap-2">
+          <DirectionButton
+            label="Продать"
+            isActive={draft.direction === 'INFLOW'}
+            tone="sell"
+            onClick={() => patchDraft({ direction: 'INFLOW' })}
+          />
+          <DirectionButton
+            label="Купить"
+            isActive={draft.direction === 'OUTFLOW'}
+            tone="buy"
+            onClick={() => patchDraft({ direction: 'OUTFLOW' })}
+          />
+        </div>
+      </div>
+
+      <label className="mt-4 block text-xs text-slate-600">
+        Инструмент
+        <InstrumentSearchField
+          key={selectedAccountId ?? 'unselected-account'}
+          account={selectedAccount}
+          value={draft.instrumentSymbol}
+          onChange={(instrumentSymbol) =>
+            patchDraft({
+              instrumentSymbol,
+            })
+          }
+        />
+      </label>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <label className="text-xs text-slate-600">
+          Дата
+          <input
+            type="date"
+            value={draft.occurredOn}
+            onChange={(event) =>
+              patchDraft({
+                occurredOn: event.target.value,
+              })
+            }
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          />
+        </label>
+
+        <label className="text-xs text-slate-600">
+          Цена
+          <input
+            type="text"
+            inputMode="decimal"
+            value={draft.unitPrice}
+            onChange={(event) =>
+              patchDraft({
+                unitPrice: formatMoneyInput(event.target.value),
+              })
+            }
+            placeholder="0.00"
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          />
+        </label>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <label className="text-xs text-slate-600">
+          Количество
+          <input
+            type="text"
+            inputMode="decimal"
+            value={draft.quantity}
+            onChange={(event) =>
+              patchDraft({
+                quantity: formatDecimalInput(event.target.value, 6),
+              })
+            }
+            placeholder="1"
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          />
+        </label>
+
+        <label className="text-xs text-slate-600">
+          Комиссия
+          <input
+            type="text"
+            inputMode="decimal"
+            value={draft.feeAmount}
+            onChange={(event) =>
+              patchDraft({
+                feeAmount: formatMoneyInput(event.target.value),
+              })
+            }
+            placeholder="0.00"
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+          />
+        </label>
+      </div>
+
+      <label className="mt-3 block text-xs text-slate-600">
+        Заметки
+        <div className="mt-1 flex items-center justify-between text-[11px] text-slate-400">
+          <span>Опционально</span>
+          <span>{draft.memo.length}/128</span>
+        </div>
+        <textarea
+          value={draft.memo}
+          onChange={(event) =>
+            patchDraft({
+              memo: event.target.value,
+            })
+          }
+          maxLength={128}
+          rows={4}
+          placeholder="Комментарии"
+          className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-2 text-sm text-slate-800"
+        />
+      </label>
+
+      <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+        <p className="text-xs uppercase tracking-wide text-slate-500">Итого</p>
+        <div className="mt-1 flex items-baseline justify-between gap-3">
+          <p
+            className={`text-lg font-semibold ${
+              draft.direction === 'OUTFLOW' ? 'text-rose-700' : 'text-emerald-700'
+            }`}
+          >
+            {evaluation.totalAmount
+              ? formatSignedAmount(evaluation.totalAmount, draft.direction)
+              : '0,00'}
+          </p>
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            {currency}
+          </p>
+        </div>
+      </div>
+
+      {validationMessages.length > 0 ? (
+        <div className="mt-3 space-y-1">
+          {validationMessages.map((message) => (
+            <p key={message} className="text-xs text-amber-700">
+              {message}
+            </p>
+          ))}
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <p className="mt-3 text-xs text-amber-700">{errorMessage}</p>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600"
+        >
+          Отмена
+        </button>
+        <button
+          type="button"
+          disabled={!canSubmit}
+          onClick={onSubmit}
+          className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitLabel}
+        </button>
+        {onSecondarySubmit && secondarySubmitLabel ? (
+          <button
+            type="button"
+            disabled={!canSubmit}
+            onClick={onSecondarySubmit}
+            className="rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {secondarySubmitLabel}
+          </button>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+interface DirectionButtonProps {
+  label: string
+  isActive: boolean
+  tone: 'buy' | 'sell'
+  onClick: () => void
+}
+
+function DirectionButton({
+  label,
+  isActive,
+  tone,
+  onClick,
+}: DirectionButtonProps) {
+  const activeClassName =
+    tone === 'buy'
+      ? 'border-blue-500 bg-blue-50 text-blue-700'
+      : 'border-rose-500 bg-rose-50 text-rose-700'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md border px-3 py-2 text-sm font-medium ${
+        isActive
+          ? activeClassName
+          : 'border-slate-300 bg-white text-slate-600'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+function toTransactionTitle(transaction: TransactionDto): string {
+  if (transaction.instrumentSymbol) {
+    return transaction.instrumentSymbol
+  }
+
+  return toTransactionMemoDisplay(transaction.memo)
+}
+
+function formatDecimalDisplay(value: string): string {
+  const [integerPart, fractionPart = ''] = value.split('.')
+  const trimmedFraction = fractionPart.replace(/0+$/, '')
+
+  return trimmedFraction.length > 0
+    ? `${integerPart},${trimmedFraction}`
+    : integerPart
 }

--- a/frontend/src/features/investments/InvestmentsView.tsx
+++ b/frontend/src/features/investments/InvestmentsView.tsx
@@ -5,23 +5,27 @@ import {
   type CreateAccountRequest,
   type CreateTransactionRequest,
   type ImportTransactionsCsvResponse,
-  type TransactionDirection,
   type TransactionDto,
   type UpdateAccountRequest,
   type UpdateTransactionRequest,
 } from '../../api'
-import { formatMoneyInput, normalizeMoneyInput } from '../../money-input'
 import {
-  isValidIsoDateValue,
-  isValidPositiveAmountValue,
-  normalizeTransactionMemo,
+  isMoexTradeAccountType,
   toInvestmentAccountCountLabel,
-  todayIsoDate,
 } from './formatting'
 import { InvestmentOverviewTab } from './InvestmentOverviewTab'
 import { InvestmentSettingsTab } from './InvestmentSettingsTab'
 import { InvestmentTransactionsTab } from './InvestmentTransactionsTab'
 import { INVESTMENT_TAB_COPY } from './model'
+import {
+  canSubmitTransactionTrade,
+  createEmptyTransactionTradeDraft,
+  createTransactionTradeDraftFromTransaction,
+  evaluateTransactionTradeDraft,
+  type TransactionTradeDraft,
+  toCreateTransactionTradeRequest,
+  toUpdateTransactionTradeRequest,
+} from './transactionTrade'
 import type {
   AccountWithBalance,
   CreateAccountStatus,
@@ -56,6 +60,7 @@ interface InvestmentsViewProps {
   transactionsErrorMessage: string | null
   filteredTransactions: TransactionDto[]
   totalTransactionsCount: number
+  selectedAccountTransactionsCount: number
   directionFilter: TransactionDirectionFilter
   memoFilter: string
   onDirectionFilterChange: (value: TransactionDirectionFilter) => void
@@ -102,6 +107,7 @@ export function InvestmentsView({
   transactionsErrorMessage,
   filteredTransactions,
   totalTransactionsCount,
+  selectedAccountTransactionsCount,
   directionFilter,
   memoFilter,
   onDirectionFilterChange,
@@ -149,25 +155,19 @@ export function InvestmentsView({
   >(null)
   const [deleteAccountErrorAccountId, setDeleteAccountErrorAccountId] =
     useState<string | null>(null)
-  const [newTransactionDate, setNewTransactionDate] =
-    useState<string>(todayIsoDate())
-  const [newTransactionDirection, setNewTransactionDirection] =
-    useState<TransactionDirection>('OUTFLOW')
-  const [newTransactionAmount, setNewTransactionAmount] = useState<string>('')
-  const [newTransactionMemo, setNewTransactionMemo] = useState<string>('')
+  const [newTransactionDraft, setNewTransactionDraft] =
+    useState<TransactionTradeDraft>(() =>
+      createEmptyTransactionTradeDraft(
+        resolvePreferredTransactionAccountId(accounts, selectedAccountId, null),
+      ),
+    )
   const [editingTransactionAccountId, setEditingTransactionAccountId] =
     useState<string | null>(null)
   const [editingTransactionId, setEditingTransactionId] = useState<
     string | null
   >(null)
-  const [editingTransactionDate, setEditingTransactionDate] =
-    useState<string>(todayIsoDate())
-  const [editingTransactionDirection, setEditingTransactionDirection] =
-    useState<TransactionDirection>('OUTFLOW')
-  const [editingTransactionAmount, setEditingTransactionAmount] =
-    useState<string>('')
-  const [editingTransactionMemo, setEditingTransactionMemo] =
-    useState<string>('')
+  const [editingTransactionDraft, setEditingTransactionDraft] =
+    useState<TransactionTradeDraft>(() => createEmptyTransactionTradeDraft())
   const [updateTransactionStatus, setUpdateTransactionStatus] =
     useState<CreateTransactionStatus>('idle')
   const [updateTransactionErrorMessage, setUpdateTransactionErrorMessage] =
@@ -198,10 +198,7 @@ export function InvestmentsView({
   const resetEditingTransaction = (): void => {
     setEditingTransactionAccountId(null)
     setEditingTransactionId(null)
-    setEditingTransactionDate(todayIsoDate())
-    setEditingTransactionDirection('OUTFLOW')
-    setEditingTransactionAmount('')
-    setEditingTransactionMemo('')
+    setEditingTransactionDraft(createEmptyTransactionTradeDraft())
     setUpdateTransactionStatus('idle')
     setUpdateTransactionErrorMessage(null)
   }
@@ -241,46 +238,53 @@ export function InvestmentsView({
     updateAccountStatus !== 'submitting'
   const isDeleteAvailabilityKnown = transactionsStatus === 'ready'
   const hasLoadedTransactions =
-    isDeleteAvailabilityKnown && totalTransactionsCount > 0
+    isDeleteAvailabilityKnown && selectedAccountTransactionsCount > 0
   const canDeleteAccount =
     selectedAccount !== null &&
     !isEditingSelectedAccount &&
     isDeleteAvailabilityKnown &&
-    totalTransactionsCount === 0 &&
+    selectedAccountTransactionsCount === 0 &&
     deleteAccountStatus !== 'submitting'
+  const resolvedNewTransactionDraft =
+    newTransactionDraft.accountId ===
+    resolvePreferredTransactionAccountId(
+      accounts,
+      selectedAccountId,
+      newTransactionDraft.accountId,
+    )
+      ? newTransactionDraft
+      : {
+          ...newTransactionDraft,
+          accountId: resolvePreferredTransactionAccountId(
+            accounts,
+            selectedAccountId,
+            newTransactionDraft.accountId,
+          ),
+        }
 
-  const transactionDateCandidate = newTransactionDate.trim()
-  const transactionAmountCandidate = normalizeMoneyInput(newTransactionAmount)
-  const transactionMemoCandidate = newTransactionMemo.trim()
-  const isTransactionDateValid = isValidIsoDateValue(transactionDateCandidate)
-  const isTransactionAmountValid = isValidPositiveAmountValue(
-    transactionAmountCandidate,
+  const newTransactionEvaluation = evaluateTransactionTradeDraft(
+    resolvedNewTransactionDraft,
   )
+  const newTransactionAccount =
+    accounts.find(
+      (account) => account.id === resolvedNewTransactionDraft.accountId,
+    ) ??
+    null
   const canCreateTransaction =
-    selectedAccount !== null &&
-    isTransactionDateValid &&
-    isTransactionAmountValid &&
+    newTransactionAccount !== null &&
+    isMoexTradeAccountType(newTransactionAccount.type) &&
+    canSubmitTransactionTrade(newTransactionEvaluation) &&
     createTransactionStatus !== 'submitting'
-  const editingTransactionDateCandidate = editingTransactionDate.trim()
-  const editingTransactionAmountCandidate = normalizeMoneyInput(
-    editingTransactionAmount,
+  const editingTransactionEvaluation = evaluateTransactionTradeDraft(
+    editingTransactionDraft,
   )
-  const editingTransactionMemoCandidate = editingTransactionMemo.trim()
-  const isEditingTransactionDateValid = isValidIsoDateValue(
-    editingTransactionDateCandidate,
-  )
-  const isEditingTransactionAmountValid = isValidPositiveAmountValue(
-    editingTransactionAmountCandidate,
-  )
-  const activeEditingTransactionId =
-    editingTransactionAccountId === selectedAccountId
-      ? editingTransactionId
-      : null
+  const editingTransactionAccount =
+    accounts.find((account) => account.id === editingTransactionAccountId) ?? null
+  const activeEditingTransactionId = editingTransactionId
   const canUpdateTransaction =
-    selectedAccount !== null &&
+    editingTransactionAccount !== null &&
     activeEditingTransactionId !== null &&
-    isEditingTransactionDateValid &&
-    isEditingTransactionAmountValid &&
+    canSubmitTransactionTrade(editingTransactionEvaluation) &&
     updateTransactionStatus !== 'submitting'
   const canImportCsv =
     selectedAccount !== null &&
@@ -377,26 +381,33 @@ export function InvestmentsView({
   }
 
   const handleCreateTransactionSubmit = async (
-    event: FormEvent<HTMLFormElement>,
+    options: { resetAfterSave: boolean } = { resetAfterSave: false },
   ): Promise<void> => {
-    event.preventDefault()
+    if (!newTransactionAccount || !canCreateTransaction) {
+      return
+    }
 
-    if (!selectedAccount || !canCreateTransaction) {
+    const request = toCreateTransactionTradeRequest(newTransactionEvaluation)
+    if (!request) {
       return
     }
 
     resetDeleteAccountState()
-    const created = await onCreateTransaction(selectedAccount.id, {
-      occurredOn: transactionDateCandidate,
-      direction: newTransactionDirection,
-      amount: transactionAmountCandidate,
-      memo: transactionMemoCandidate,
-    })
+    const created = await onCreateTransaction(newTransactionAccount.id, request)
 
     if (created) {
-      setNewTransactionAmount('')
-      setNewTransactionMemo('')
+      if (options.resetAfterSave) {
+        setNewTransactionDraft(
+          createEmptyTransactionTradeDraft(resolvedNewTransactionDraft.accountId),
+        )
+      }
     }
+  }
+
+  const handleResetNewTransaction = (): void => {
+    setNewTransactionDraft(
+      createEmptyTransactionTradeDraft(resolvedNewTransactionDraft.accountId),
+    )
   }
 
   const handleImportCsvSubmit = async (
@@ -422,26 +433,26 @@ export function InvestmentsView({
 
   const handleStartEditingTransaction = (transaction: TransactionDto): void => {
     resetDeleteTransactionState()
-    setEditingTransactionAccountId(selectedAccountId)
+    setEditingTransactionAccountId(transaction.accountId)
     setEditingTransactionId(transaction.id)
-    setEditingTransactionDate(transaction.occurredOn)
-    setEditingTransactionDirection(transaction.direction)
-    setEditingTransactionAmount(formatMoneyInput(transaction.amount))
-    setEditingTransactionMemo(normalizeTransactionMemo(transaction.memo))
+    setEditingTransactionDraft(
+      createTransactionTradeDraftFromTransaction(transaction),
+    )
     setUpdateTransactionStatus('idle')
     setUpdateTransactionErrorMessage(null)
   }
 
-  const handleUpdateTransactionSubmit = async (
-    event: FormEvent<HTMLFormElement>,
-  ): Promise<void> => {
-    event.preventDefault()
-
+  const handleUpdateTransactionSubmit = async (): Promise<void> => {
     if (
-      !selectedAccount ||
+      !editingTransactionAccount ||
       !activeEditingTransactionId ||
       !canUpdateTransaction
     ) {
+      return
+    }
+
+    const request = toUpdateTransactionTradeRequest(editingTransactionEvaluation)
+    if (!request) {
       return
     }
 
@@ -451,14 +462,9 @@ export function InvestmentsView({
 
     try {
       await onUpdateTransaction(
-        selectedAccount.id,
+        editingTransactionAccount.id,
         activeEditingTransactionId,
-        {
-          occurredOn: editingTransactionDateCandidate,
-          direction: editingTransactionDirection,
-          amount: editingTransactionAmountCandidate,
-          memo: editingTransactionMemoCandidate,
-        },
+        request,
       )
       resetEditingTransaction()
     } catch (error) {
@@ -470,7 +476,7 @@ export function InvestmentsView({
   const handleDeleteTransactionClick = async (
     transaction: TransactionDto,
   ): Promise<void> => {
-    if (!selectedAccount || isDeleteTransactionSubmitting) {
+    if (isDeleteTransactionSubmitting) {
       return
     }
 
@@ -479,7 +485,7 @@ export function InvestmentsView({
     setDeleteTransactionErrorMessage(null)
 
     try {
-      await onDeleteTransaction(selectedAccount.id, transaction.id)
+      await onDeleteTransaction(transaction.accountId, transaction.id)
       if (activeEditingTransactionId === transaction.id) {
         resetEditingTransaction()
       }
@@ -496,10 +502,7 @@ export function InvestmentsView({
     resetDeleteAccountState()
     resetEditingTransaction()
     resetDeleteTransactionState()
-    setNewTransactionDate(todayIsoDate())
-    setNewTransactionDirection('OUTFLOW')
-    setNewTransactionAmount('')
-    setNewTransactionMemo('')
+    setNewTransactionDraft(createEmptyTransactionTradeDraft(accountId))
     setCsvFile(null)
     if (csvFileInputRef.current) {
       csvFileInputRef.current.value = ''
@@ -576,8 +579,6 @@ export function InvestmentsView({
       {activeInvestmentTab === 'transactions' ? (
         <InvestmentTransactionsTab
           accounts={accounts}
-          selectedAccountId={selectedAccountId}
-          selectedAccount={selectedAccount}
           transactionsStatus={transactionsStatus}
           transactionsErrorMessage={transactionsErrorMessage}
           filteredTransactions={filteredTransactions}
@@ -586,30 +587,27 @@ export function InvestmentsView({
           memoFilter={memoFilter}
           onDirectionFilterChange={onDirectionFilterChange}
           onMemoFilterChange={onMemoFilterChange}
-          onSelectAccount={handleSelectAccountClick}
           createTransactionStatus={createTransactionStatus}
           createTransactionErrorMessage={createTransactionErrorMessage}
-          newTransactionDate={newTransactionDate}
-          newTransactionDirection={newTransactionDirection}
-          newTransactionAmount={newTransactionAmount}
-          newTransactionMemo={newTransactionMemo}
-          onNewTransactionDateChange={setNewTransactionDate}
-          onNewTransactionDirectionChange={setNewTransactionDirection}
-          onNewTransactionAmountChange={setNewTransactionAmount}
-          onNewTransactionMemoChange={setNewTransactionMemo}
-          isTransactionAmountValid={isTransactionAmountValid}
+          newTransactionDraft={resolvedNewTransactionDraft}
+          newTransactionEvaluation={newTransactionEvaluation}
+          newTransactionAccount={newTransactionAccount}
+          onNewTransactionDraftChange={setNewTransactionDraft}
+          onNewTransactionAccountChange={(accountId) =>
+            setNewTransactionDraft((current) => ({
+              ...current,
+              accountId,
+              instrumentSymbol: '',
+            }))
+          }
           canCreateTransaction={canCreateTransaction}
           onCreateTransactionSubmit={handleCreateTransactionSubmit}
+          onResetNewTransaction={handleResetNewTransaction}
           activeEditingTransactionId={activeEditingTransactionId}
-          editingTransactionDate={editingTransactionDate}
-          editingTransactionDirection={editingTransactionDirection}
-          editingTransactionAmount={editingTransactionAmount}
-          editingTransactionMemo={editingTransactionMemo}
-          onEditingTransactionDateChange={setEditingTransactionDate}
-          onEditingTransactionDirectionChange={setEditingTransactionDirection}
-          onEditingTransactionAmountChange={setEditingTransactionAmount}
-          onEditingTransactionMemoChange={setEditingTransactionMemo}
-          isEditingTransactionAmountValid={isEditingTransactionAmountValid}
+          editingTransactionDraft={editingTransactionDraft}
+          editingTransactionEvaluation={editingTransactionEvaluation}
+          editingTransactionAccount={editingTransactionAccount}
+          onEditingTransactionDraftChange={setEditingTransactionDraft}
           canUpdateTransaction={canUpdateTransaction}
           updateTransactionStatus={updateTransactionStatus}
           updateTransactionErrorMessage={updateTransactionErrorMessage}
@@ -675,6 +673,32 @@ export function InvestmentsView({
       ) : null}
     </div>
   )
+}
+
+function resolvePreferredTransactionAccountId(
+  accounts: AccountWithBalance[],
+  selectedAccountId: string | null,
+  currentAccountId: string | null,
+): string {
+  const supportedAccounts = accounts.filter((account) =>
+    isMoexTradeAccountType(account.type),
+  )
+
+  if (
+    currentAccountId &&
+    supportedAccounts.some((account) => account.id === currentAccountId)
+  ) {
+    return currentAccountId
+  }
+
+  if (
+    selectedAccountId &&
+    supportedAccounts.some((account) => account.id === selectedAccountId)
+  ) {
+    return selectedAccountId
+  }
+
+  return supportedAccounts[0]?.id ?? ''
 }
 
 function toErrorMessage(error: unknown): string {

--- a/frontend/src/features/investments/formatting.ts
+++ b/frontend/src/features/investments/formatting.ts
@@ -1,4 +1,4 @@
-import type { AccountType, TransactionDirection } from '../../api'
+import type { AccountType, InstrumentKind, TransactionDirection } from '../../api'
 import type { AccountStatus } from './types'
 
 export function addDecimalAmountsExact(left: string, right: string): string {
@@ -57,13 +57,13 @@ export function formatIsoDateRu(isoDate: string): string {
 }
 
 export function toDirectionLabel(direction: TransactionDirection): string {
-  return toDirectionSelectLabel(direction)
+  return direction === 'INFLOW' ? 'Продажа' : 'Покупка'
 }
 
 export function toDirectionSelectLabel(
   direction: TransactionDirection,
 ): string {
-  return direction === 'INFLOW' ? 'Доход' : 'Расход'
+  return direction === 'INFLOW' ? 'Продать' : 'Купить'
 }
 
 export function toAccountTypeLabel(type: AccountType): string {
@@ -75,6 +75,19 @@ export function toAccountTypeLabel(type: AccountType): string {
     BROKERAGE: 'Брокерский',
   }
   return labels[type]
+}
+
+export function isMoexTradeAccountType(type: AccountType): boolean {
+  return type === 'BROKERAGE' || type === 'IIS'
+}
+
+export function toInstrumentKindLabel(kind: InstrumentKind): string {
+  const labels: Record<InstrumentKind, string> = {
+    SHARE: 'Акция',
+    FUND: 'Фонд',
+    BOND: 'Облигация',
+  }
+  return labels[kind]
 }
 
 export function toAccountStatusLabel(status: AccountStatus): string {

--- a/frontend/src/features/investments/transactionTrade.ts
+++ b/frontend/src/features/investments/transactionTrade.ts
@@ -1,0 +1,377 @@
+import type {
+  CreateTransactionRequest,
+  DecimalAmount,
+  TransactionDirection,
+  TransactionDto,
+  UpdateTransactionRequest,
+} from '../../api'
+import { formatMoneyInput, normalizeMoneyInput } from '../../money-input'
+import { isValidIsoDateValue, normalizeTransactionMemo, todayIsoDate } from './formatting'
+
+export interface TransactionTradeDraft {
+  accountId: string
+  occurredOn: string
+  direction: TransactionDirection
+  instrumentSymbol: string
+  unitPrice: string
+  quantity: string
+  feeAmount: string
+  memo: string
+}
+
+export interface TransactionTradeEvaluation {
+  occurredOn: string
+  direction: TransactionDirection
+  instrumentSymbol: string
+  unitPrice: DecimalAmount
+  quantity: DecimalAmount
+  feeAmount: DecimalAmount
+  memo: string
+  totalAmount: DecimalAmount | null
+  isDateValid: boolean
+  isInstrumentSymbolValid: boolean
+  isUnitPriceValid: boolean
+  isQuantityValid: boolean
+  isFeeAmountValid: boolean
+  isTotalAmountValid: boolean
+}
+
+const DEFAULT_DRAFT: TransactionTradeDraft = {
+  accountId: '',
+  occurredOn: todayIsoDate(),
+  direction: 'OUTFLOW',
+  instrumentSymbol: '',
+  unitPrice: '',
+  quantity: '1',
+  feeAmount: '0',
+  memo: '',
+}
+
+export function createEmptyTransactionTradeDraft(
+  accountId: string = '',
+): TransactionTradeDraft {
+  return {
+    ...DEFAULT_DRAFT,
+    accountId,
+    occurredOn: todayIsoDate(),
+  }
+}
+
+export function createTransactionTradeDraftFromTransaction(
+  transaction: TransactionDto,
+): TransactionTradeDraft {
+  return {
+    accountId: transaction.accountId,
+    occurredOn: transaction.occurredOn,
+    direction: transaction.direction,
+    instrumentSymbol: transaction.instrumentSymbol ?? '',
+    unitPrice: formatMoneyInput(transaction.unitPrice ?? transaction.amount),
+    quantity: formatDecimalInput(transaction.quantity ?? '1', 6),
+    feeAmount: formatMoneyInput(transaction.feeAmount ?? '0'),
+    memo: normalizeTransactionMemo(transaction.memo),
+  }
+}
+
+export function evaluateTransactionTradeDraft(
+  draft: TransactionTradeDraft,
+): TransactionTradeEvaluation {
+  const occurredOn = draft.occurredOn.trim()
+  const instrumentSymbol = normalizeInstrumentSymbol(draft.instrumentSymbol)
+  const unitPrice = normalizeMoneyInput(draft.unitPrice)
+  const quantity = normalizeDecimalInput(draft.quantity, 6)
+  const feeAmountCandidate = normalizeMoneyInput(draft.feeAmount)
+  const feeAmount = feeAmountCandidate.length > 0 ? feeAmountCandidate : '0'
+  const memo = draft.memo.trim()
+  const totalAmount =
+    isValidIsoDateValue(occurredOn) &&
+    instrumentSymbol.length > 0 &&
+    isValidPositiveAmountValue(unitPrice, 2) &&
+    isValidPositiveAmountValue(quantity, 6) &&
+    isValidNonNegativeAmountValue(feeAmount, 2)
+      ? computeTradeTotalAmount({
+          direction: draft.direction,
+          unitPrice,
+          quantity,
+          feeAmount,
+        })
+      : null
+
+  return {
+    occurredOn,
+    direction: draft.direction,
+    instrumentSymbol,
+    unitPrice,
+    quantity,
+    feeAmount,
+    memo,
+    totalAmount,
+    isDateValid: isValidIsoDateValue(occurredOn),
+    isInstrumentSymbolValid: instrumentSymbol.length > 0,
+    isUnitPriceValid: isValidPositiveAmountValue(unitPrice, 2),
+    isQuantityValid: isValidPositiveAmountValue(quantity, 6),
+    isFeeAmountValid: isValidNonNegativeAmountValue(feeAmount, 2),
+    isTotalAmountValid: totalAmount !== null,
+  }
+}
+
+export function toCreateTransactionTradeRequest(
+  evaluation: TransactionTradeEvaluation,
+): CreateTransactionRequest | null {
+  if (!isTransactionTradeEvaluationValid(evaluation)) {
+    return null
+  }
+
+  return {
+    occurredOn: evaluation.occurredOn,
+    direction: evaluation.direction,
+    amount: evaluation.totalAmount ?? undefined,
+    memo: evaluation.memo,
+    instrumentSymbol: evaluation.instrumentSymbol,
+    quantity: evaluation.quantity,
+    unitPrice: evaluation.unitPrice,
+    feeAmount: evaluation.feeAmount,
+  }
+}
+
+export function toUpdateTransactionTradeRequest(
+  evaluation: TransactionTradeEvaluation,
+): UpdateTransactionRequest | null {
+  if (!isTransactionTradeEvaluationValid(evaluation)) {
+    return null
+  }
+
+  return {
+    occurredOn: evaluation.occurredOn,
+    direction: evaluation.direction,
+    amount: evaluation.totalAmount ?? undefined,
+    memo: evaluation.memo,
+    instrumentSymbol: evaluation.instrumentSymbol,
+    quantity: evaluation.quantity,
+    unitPrice: evaluation.unitPrice,
+    feeAmount: evaluation.feeAmount,
+  }
+}
+
+export function canSubmitTransactionTrade(
+  evaluation: TransactionTradeEvaluation,
+): boolean {
+  return isTransactionTradeEvaluationValid(evaluation)
+}
+
+export function formatDecimalInput(value: string, maxFractionDigits: number): string {
+  const normalized = normalizeDecimalInput(value, maxFractionDigits)
+  if (normalized.length === 0) {
+    return ''
+  }
+
+  const [integerRaw, fractionRaw = ''] = normalized.split('.')
+  const integerPart = integerRaw.replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+  return fractionRaw.length > 0 ? `${integerPart}.${fractionRaw}` : integerPart
+}
+
+export function normalizeDecimalInput(value: string, maxFractionDigits: number): string {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return ''
+  }
+
+  const source = trimmed.replace(/\s+/g, '')
+  if (/[+-]/.test(source) || /[^0-9.,]/.test(source)) {
+    return value.trim()
+  }
+
+  const dotCount = countOccurrences(source, '.')
+  const commaCount = countOccurrences(source, ',')
+  if ((dotCount > 0 && commaCount > 0) || dotCount > 1 || commaCount > 1) {
+    return value.trim()
+  }
+
+  const decimalSeparator = dotCount === 1 ? '.' : commaCount === 1 ? ',' : null
+  const [integerRaw, fractionRaw = ''] =
+    decimalSeparator === null ? [source, ''] : source.split(decimalSeparator)
+
+  if (!/^\d*$/.test(integerRaw) || !/^\d*$/.test(fractionRaw)) {
+    return value.trim()
+  }
+
+  const integerPart = integerRaw.replace(/^0+(?=\d)/, '') || '0'
+  const fractionPart = fractionRaw.slice(0, maxFractionDigits)
+
+  if (decimalSeparator === null) {
+    return integerPart
+  }
+
+  return `${integerPart}.${fractionPart}`
+}
+
+export function normalizeInstrumentSymbol(value: string): string {
+  return value.trim().toUpperCase()
+}
+
+export function computeTradeTotalAmount(input: {
+  direction: TransactionDirection
+  unitPrice: DecimalAmount
+  quantity: DecimalAmount
+  feeAmount: DecimalAmount
+}): DecimalAmount | null {
+  const unitPriceDecimal = parseDecimal(input.unitPrice)
+  const quantityDecimal = parseDecimal(input.quantity)
+  const feeAmountDecimal = parseDecimal(input.feeAmount)
+
+  if (!unitPriceDecimal || !quantityDecimal || !feeAmountDecimal) {
+    return null
+  }
+
+  const grossAmount = multiplyDecimals(unitPriceDecimal, quantityDecimal)
+  const totalAmount =
+    input.direction === 'OUTFLOW'
+      ? addDecimals(grossAmount, feeAmountDecimal)
+      : subtractDecimals(grossAmount, feeAmountDecimal)
+
+  if (totalAmount.sign < 0) {
+    return null
+  }
+
+  return toCurrencyAmountString(totalAmount)
+}
+
+export function toTradeDirectionLabel(direction: TransactionDirection): string {
+  return direction === 'OUTFLOW' ? 'Купить' : 'Продать'
+}
+
+export function isBuyDirection(direction: TransactionDirection): boolean {
+  return direction === 'OUTFLOW'
+}
+
+function isTransactionTradeEvaluationValid(
+  evaluation: TransactionTradeEvaluation,
+): boolean {
+  return (
+    evaluation.isDateValid &&
+    evaluation.isInstrumentSymbolValid &&
+    evaluation.isUnitPriceValid &&
+    evaluation.isQuantityValid &&
+    evaluation.isFeeAmountValid &&
+    evaluation.isTotalAmountValid
+  )
+}
+
+function isValidPositiveAmountValue(
+  value: string,
+  maxFractionDigits: number,
+): boolean {
+  return isValidAmountValue(value, maxFractionDigits, { allowZero: false })
+}
+
+function isValidNonNegativeAmountValue(
+  value: string,
+  maxFractionDigits: number,
+): boolean {
+  return isValidAmountValue(value, maxFractionDigits, { allowZero: true })
+}
+
+function isValidAmountValue(
+  value: string,
+  maxFractionDigits: number,
+  options: { allowZero: boolean },
+): boolean {
+  if (!new RegExp(`^(?:0|[1-9]\\d*)(?:\\.\\d{1,${maxFractionDigits}})?$`).test(value)) {
+    return false
+  }
+
+  if (options.allowZero) {
+    return true
+  }
+
+  return parseDecimal(value)?.sign === 1
+}
+
+interface ParsedDecimal {
+  sign: -1 | 0 | 1
+  scale: number
+  value: bigint
+}
+
+function parseDecimal(value: string): ParsedDecimal | null {
+  const normalized = value.trim()
+  if (!/^\d+(?:\.\d+)?$/.test(normalized)) {
+    return null
+  }
+
+  const [integerPart, fractionPart = ''] = normalized.split('.')
+  const digits = `${integerPart}${fractionPart}`
+  const bigintValue = BigInt(digits)
+
+  return {
+    sign: bigintValue === 0n ? 0 : 1,
+    scale: fractionPart.length,
+    value: bigintValue,
+  }
+}
+
+function multiplyDecimals(left: ParsedDecimal, right: ParsedDecimal): ParsedDecimal {
+  const value = left.value * right.value
+  return {
+    sign: value === 0n ? 0 : 1,
+    scale: left.scale + right.scale,
+    value,
+  }
+}
+
+function addDecimals(left: ParsedDecimal, right: ParsedDecimal): ParsedDecimal {
+  const scale = Math.max(left.scale, right.scale)
+  const value = alignDecimal(left, scale) + alignDecimal(right, scale)
+  return {
+    sign: value === 0n ? 0 : 1,
+    scale,
+    value,
+  }
+}
+
+function subtractDecimals(left: ParsedDecimal, right: ParsedDecimal): ParsedDecimal {
+  const scale = Math.max(left.scale, right.scale)
+  const value = alignDecimal(left, scale) - alignDecimal(right, scale)
+  return {
+    sign: value === 0n ? 0 : value > 0n ? 1 : -1,
+    scale,
+    value,
+  }
+}
+
+function alignDecimal(value: ParsedDecimal, scale: number): bigint {
+  const multiplier = 10n ** BigInt(scale - value.scale)
+  return value.value * multiplier
+}
+
+function toCurrencyAmountString(value: ParsedDecimal): DecimalAmount | null {
+  const normalized = trimTrailingZeros(value.value, value.scale)
+  if (normalized.scale > 2) {
+    return null
+  }
+
+  const scale = 2
+  const alignedValue = normalized.value * 10n ** BigInt(scale - normalized.scale)
+  const integerPart = alignedValue / 100n
+  const fractionPart = String(alignedValue % 100n).padStart(2, '0')
+  return `${integerPart}.${fractionPart}`
+}
+
+function trimTrailingZeros(value: bigint, scale: number): ParsedDecimal {
+  let currentValue = value
+  let currentScale = scale
+
+  while (currentScale > 0 && currentValue % 10n === 0n) {
+    currentValue /= 10n
+    currentScale -= 1
+  }
+
+  return {
+    sign: currentValue === 0n ? 0 : 1,
+    scale: currentScale,
+    value: currentValue,
+  }
+}
+
+function countOccurrences(value: string, symbol: string): number {
+  return value.split(symbol).length - 1
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,13 +2,22 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const apiPort = process.env.MINDFUL_FINANCE_API_PORT ?? '8080'
+const frontendPort = Number.parseInt(
+  process.env.MINDFUL_FINANCE_FRONTEND_PORT ?? '5173',
+  10,
+)
+const proxyTarget =
+  process.env.VITE_DEV_PROXY_TARGET ?? `http://localhost:${apiPort}`
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    port: Number.isNaN(frontendPort) ? 5173 : frontendPort,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: proxyTarget,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },


### PR DESCRIPTION
## What changed
- added an end-to-end investment trade workflow across domain, application, API, Postgres, and frontend
- expanded investment transactions to support instrument symbol, quantity, unit price, fee amount, and server-side total calculation
- added a global `GET /investment-transactions` endpoint so the transactions tab shows deals across investment accounts instead of being scoped to one selected account
- added a MOEX-backed instrument picker with account-type filtering: brokerage accounts search shares and funds, IIS accounts search bonds
- added a narrow frontend transaction decoder/normalizer so transaction payload drift is caught at the API boundary instead of crashing in render

## Why it changed
The investments flow had grown beyond a cash-only transaction model. The UI now needs to represent real investment deals with instrument-specific fields, account-aware transaction creation, and a global transaction view.

## User and developer impact
- users can create investment trades with account selection, instrument search, price, quantity, fee, and derived total
- the transactions tab shows all investment trades and keeps row actions tied to the correct account
- developers now have a stable transaction wire boundary on the frontend and explicit backend use cases for global investment listing and MOEX instrument lookup

## Root cause fixed in this PR
After the first saved trade, the transactions tab could crash because trade decimal fields were rendered as strings on the frontend, but the backend could return them as numeric JSON values. The PR aligns the backend DTO shape and adds a frontend decoder/normalizer to guard the boundary.

## Validation
- `mvn --batch-mode -f backend/pom.xml test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- manual browser repro: open Investments -> Transactions after creating the first transaction and verify the tab renders without runtime errors
